### PR TITLE
Remove Queue reference from NodeGroup overprovisioning example

### DIFF
--- a/docs/examples/reserved-capacity-utilization.yaml
+++ b/docs/examples/reserved-capacity-utilization.yaml
@@ -11,7 +11,6 @@ spec:
       eks.amazonaws.com/nodegroup: default
 ---
 ###
-# Track the queue_length metric.
 # Maintain 60% utilization of CPU or Memory (whichever is greater)
 # Set the desired replicas on scaleTargetRef of the Node Group below
 ###


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Removes an errant line referring to the `queue_length` metric from the [queue-length-average-value example](https://github.com/awslabs/karpenter/blob/main/docs/examples/queue-length-average-value.yaml) seemingly copied into the overprovisioning example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
