### PR TITLE
Capitalise TERMS.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ kubectl apply -f https://raw.githubusercontent.com/awslabs/karpenter/master/rele
 - [Contributing](./docs/CONTRIBUTING.md)
 
 ## Terms
-Karpenter is an early stage, experimental project that is currently maintained by AWS and available as a preview. We request that you do not use Karpenter for production workloads at this time. See details in our [terms](./docs/terms.md).
+Karpenter is an early stage, experimental project that is currently maintained by AWS and available as a preview. We request that you do not use Karpenter for production workloads at this time. See details in our [terms](./docs/TERMS.md).
 
 ## License
 This project is licensed under the Apache-2.0 License.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Corrects capitalisation of the [TERMS.md link](https://github.com/awslabs/karpenter/blob/main/docs/TERMS.md), the [current link](https://github.com/awslabs/karpenter/blob/main/docs/terms.md) works locally but 404s in Github.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
