### PR TITLE
Include karpenter namespace dependency check in docs/aws/README.md

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -48,7 +48,12 @@ EOM
 
 ### Associate the IAM Role with your Kubernetes Service Account
 These commands will associate the AWS IAM Policy you created above with the Kubernetes Service Account used by Karpenter.
+The operation depends on the karpenter namespace, which will be created if missing.
 ```
+if ! kubectl get namespaces -o json | jq -r ".items[].metadata.name" | grep karpenter; then
+  kubectl create namespace karpenter
+fi
+
 eksctl utils associate-iam-oidc-provider \
 --region ${REGION} \
 --cluster ${CLUSTER_NAME} \


### PR DESCRIPTION
*Issue #, if available:*

#184 

*Description of changes:*

Setup procedure has a dependency on the `karpenter` namespace.
When following procedure prior to Karpenter installation, iamserviceaccount creation fails:

```
eksctl create iamserviceaccount --cluster ${CLUSTER_NAME} \  
--name default \  
--namespace karpenter \  
--attach-policy-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:policy/Karpenter" \  
--override-existing-serviceaccounts \  
--approve
```

PR updates https://github.com/awslabs/karpenter/blob/main/docs/aws/README.md to include step to create namespace where missing:
```
if ! kubectl get namespaces -o json | jq -r ".items[].metadata.name" | grep karpenter; then
  kubectl create namespace karpenter
fi
```

Note: Introducing `karpenter` namespace prior to running karpenter installation via Helm causes Helm install to fail.
See #184 for workarounds, including one that negates requirement to implement this PR:

> Alternate (short-term) workaround:
>  - Be prescriptive in instructing users to perform cloud provider configuration only after karpenter installation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
