### PR TITLE
Multiple updates in hack/quick-install.sh

### DIFF
--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -33,7 +33,7 @@ delete() {
   helm delete cert-manager --namespace cert-manager || true
   helm delete kube-prometheus-stack --namespace monitoring || true
 
-  kubectl delete namespace cert-manager monitoring || true #here
+  kubectl delete namespace cert-manager monitoring || true
 }
 
 # If this fails you may have an old installation hanging around.

--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -4,15 +4,17 @@ set -eu -o pipefail
 main() {
   local command=${1:-'--apply'}
   if [[ $command = "--apply" ]]; then
+    echo "Installing Karpenter & dependencies.."
     apply
     echo "Installation complete!"
   elif [[ $command = "--delete" ]]; then
+    echo "Uninstalling Karpenter & dependencies.."
     delete
     echo "Uninstallation complete!"
   else
     echo "Error: invalid argument: $command" >&2
     usage
-    exit 22			# EINVAL
+    exit 22                     # EINVAL
   fi
 }
 
@@ -27,11 +29,11 @@ EOF
 }
 
 delete() {
+  helm delete karpenter || true
   helm delete cert-manager --namespace cert-manager || true
   helm delete kube-prometheus-stack --namespace monitoring || true
-  helm delete karpenter || true
 
-  kubectl delete namespace cert-manager monitoring || true
+  kubectl delete namespace cert-manager monitoring || true #here
 }
 
 # If this fails you may have an old installation hanging around.
@@ -67,7 +69,7 @@ apply() {
     --set nodeExporter.enabled=false \
     --set prometheus.enabled=false
 
-  helm upgrade --install karpenter charts/karpenter
+  helm upgrade --install karpenter karpenter/karpenter
 }
 
 usage


### PR DESCRIPTION
*Issue #, if available:*

Issues here require resolving as independent to #184.

*Description of changes:*
File https://raw.githubusercontent.com/awslabs/karpenter/v0.1.1/hack/quick-install.sh contains two issues to be addressed:

**Install:**
Command `helm upgrade --install karpenter charts/karpenter` fails.
PR updates command to read `helm upgrade --install karpenter karpenter/karpenter`.

**Uninstall:**
Current order of operation leaves deployment: `karpenter` and statefulset: `prometheus-karpenter-monitor` remaining:
```
delete() {
  helm delete cert-manager --namespace cert-manager || true
  helm delete kube-prometheus-stack --namespace monitoring || true
  helm delete karpenter || true
```
PR changes order to move karpenter deletion to occur prior to removal of dependencies:
```
delete() {
  helm delete karpenter || true
  helm delete cert-manager --namespace cert-manager || true
  helm delete kube-prometheus-stack --namespace monitoring || true
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
