### PR TITLE
Validations for MetricsProducers

### DIFF
--- a/docs/examples/queue-length-average-value.yaml
+++ b/docs/examples/queue-length-average-value.yaml
@@ -41,5 +41,8 @@ kind: ScalableNodeGroup
 metadata:
   name: ml-training-capacity
 spec:
+  # replicas is needed here
+  # +ref https://github.com/awslabs/karpenter/issues/64
+  replicas: 1
   type: AWSEKSNodeGroup
   id: arn:aws:eks:us-west-2:1234567890:nodegroup/test-cluster/training-capacity/qwertyuiop

--- a/docs/examples/reserved-capacity-utilization.yaml
+++ b/docs/examples/reserved-capacity-utilization.yaml
@@ -42,5 +42,8 @@ kind: ScalableNodeGroup
 metadata:
   name: microservices
 spec:
+  # replicas is needed here
+  # +ref https://github.com/awslabs/karpenter/issues/64
+  replicas: 1
   type: AWSEKSNodeGroup
   id: arn:aws:eks:us-west-2:1234567890:nodegroup:test-cluster/microservices/qwertyuiop

--- a/docs/examples/scheduled-capacity.yaml
+++ b/docs/examples/scheduled-capacity.yaml
@@ -22,7 +22,7 @@ spec:
       # Scale way up for higher traffic for weekdays during work hours
       - replicas: 6
         start:
-          weekdays: mon,tue,wed,thu,fri
+          weekdays: Mon,Tue,Wed,Thu,Fri
           hours: "9"
         end:
           weekdays: Mon,Tue,Wed,Thu,Fri
@@ -60,6 +60,8 @@ kind: ScalableNodeGroup
 metadata:
   name: scheduled-nodegroup-example
 spec:
+  # replicas is needed here
+  # +ref https://github.com/awslabs/karpenter/issues/64
   replicas: 1
   type: AWSEKSNodeGroup
   id: arn:aws:eks:us-west-2:112358132134:nodegroup/fibonacci/demo/qwertyuiop

--- a/pkg/apis/autoscaling/v1alpha1/metricsproducer_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/metricsproducer_defaults.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package v1alpha1
 
-import "sigs.k8s.io/controller-runtime/pkg/webhook"
-
-var _ webhook.Defaulter = &MetricsProducer{}
-
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (m *MetricsProducer) Default() {
+func (r *MetricsProducer) Default() {
 }

--- a/pkg/apis/autoscaling/v1alpha1/metricsproducer_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/metricsproducer_defaults.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
+import "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+var _ webhook.Defaulter = &MetricsProducer{}
+
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *MetricsProducer) Default() {
+func (m *MetricsProducer) Default() {
 }

--- a/pkg/apis/autoscaling/v1alpha1/metricsproducer_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/metricsproducer_validation.go
@@ -13,29 +13,31 @@ limitations under the License.
 */
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-autoscaling-karpenter-sh-v1alpha1-metricsproducer,mutating=false,sideEffects=None,failurePolicy=fail,groups=autoscaling.karpenter.sh,resources=metricsproducers,versions=v1alpha1,name=vmetricsproducer.kb.io
-
 package v1alpha1
 
 import (
 	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
 )
+type specValidator interface {
+	validate() error
+}
 
 // Only Validates ScheduledCapacity MetricsProducer right now
 func (m *MetricsProducer) ValidateCreate() error {
-	if err := m.ValidateSchedule(); err != nil  {
-		return err
+	for _, validator := range []specValidator{
+		m.Spec.PendingCapacity,
+		m.Spec.ReservedCapacity,
+		m.Spec.Schedule,
+	} {
+		if validator != nil {
+			return validator.validate()
+		}
 	}
-	if m.Spec.ReservedCapacity != nil {
-		return m.Spec.ReservedCapacity.validate()
-	}
-	if m.Spec.PendingCapacity != nil {
-		return m.Spec.PendingCapacity.validate()
-	}
-
 	return nil
 }
 
@@ -47,27 +49,39 @@ func (m *MetricsProducer) ValidateDelete() error {
 	return nil
 }
 
-func (m *MetricsProducer) ValidateSchedule() error {
-	if m.Spec.Schedule != nil {
-		for _, b := range m.Spec.Schedule.Behaviors {
-			if err := b.Start.IsValidPattern(); err != nil {
-				return fmt.Errorf("start pattern could not be parsed, %w", err)
-			}
-			if err := b.End.IsValidPattern(); err != nil {
-				return fmt.Errorf("end pattern could not be parsed, %w", err)
-			}
-			if b.Replicas < 0 {
-				return fmt.Errorf("behavior.replicas cannot be negative")
-			}
+// Validate ScheduleSpec
+func (s *ScheduleSpec) validate() error {
+	for _, b := range s.Behaviors {
+		if err := b.Start.validate(); err != nil {
+			return fmt.Errorf("start pattern could not be parsed, %w", err)
+		}
+		if err := b.End.validate(); err != nil {
+			return fmt.Errorf("end pattern could not be parsed, %w", err)
+		}
+		if b.Replicas < 0 {
+			return fmt.Errorf("behavior.replicas cannot be negative")
 		}
 	}
-	if m.Spec.Schedule.DefaultReplicas < 0 {
+	if s.DefaultReplicas < 0 {
 		return fmt.Errorf("defaultReplicas cannot be negative")
 	}
-	if m.Spec.Schedule.Timezone != nil {
-		if _, err := time.LoadLocation(*m.Spec.Schedule.Timezone); err != nil {
+	if s.Timezone != nil {
+		if _, err := time.LoadLocation(*s.Timezone); err != nil {
 			return fmt.Errorf("timezone region could not be parsed")
 		}
+	}
+	return nil
+}
+
+// Validate PendingCapacity
+func (s *PendingCapacitySpec) validate() error {
+	return nil
+}
+
+// Validate ReservedCapacity
+func (s *ReservedCapacitySpec) validate() error {
+	if len(s.NodeSelector) != 1 {
+		return fmt.Errorf("reserved capacity must refer to exactly one node selector")
 	}
 	return nil
 }
@@ -75,25 +89,29 @@ func (m *MetricsProducer) ValidateSchedule() error {
 // These regex patterns are meant to match to one element at a time
 const (
 	weekdayRegexPattern = "^((sun(day)?|0|7)|(mon(day)?|1)|(tue(sday)?|2)|(wed(nesday)?|3)|(thu(rsday)?|4)|(fri(day)?|5)|(sat(urday)?|6))$"
-	monthRegexPattern = "^((jan(uary)?|1)|(feb(ruary)?|2)|(mar(ch)?|3)|(apr(il)?|4)|(may|5)|(june?|6)|(july?|7)|(aug(ust)?|8)|(sep(tember)?|9)|((oct(ober)?)|(10))|(nov(ember)?|(11))|(dec(ember)?|(12)))$"
-	onlyNumbersPattern = `^\d+$`
+	monthRegexPattern   = "^((jan(uary)?|1)|(feb(ruary)?|2)|(mar(ch)?|3)|(apr(il)?|4)|(may|5)|(june?|6)|(july?|7)|(aug(ust)?|8)|(sep(tember)?|9)|((oct(ober)?)|(10))|(nov(ember)?|(11))|(dec(ember)?|(12)))$"
+	onlyNumbersPattern  = `^\d+$`
 )
 
-func (p *Pattern) IsValidPattern() error {
-	if !isValidField(p.Weekdays, weekdayRegexPattern) {
-		return fmt.Errorf("weekdays field could not be parsed")
-	}
-	if !isValidField(p.Months, monthRegexPattern){
-		return fmt.Errorf("months field could not be parsed")
-	}
-	if !isValidField(p.Days, onlyNumbersPattern){
-		return fmt.Errorf("days field could not be parsed")
-	}
-	if !isValidField(p.Hours, onlyNumbersPattern) {
-		return fmt.Errorf("hours field could not be parsed")
-	}
-	if !isValidField(p.Minutes, onlyNumbersPattern) {
-		return fmt.Errorf("minutes field could not be parsed")
+func (p *Pattern) validate() error {
+	val := reflect.ValueOf(p)
+	errorMessage := "%s field could not be parsed"
+	for i, name := range []string{"Minutes","Hours","Days","Months","Weekdays"} {
+		field := val.FieldByName(name).String()
+		switch i {
+		case 3:
+			if !isValidField(&field, monthRegexPattern) {
+				return fmt.Errorf(errorMessage, name)
+			}
+		case 4:
+			if !isValidField(&field, weekdayRegexPattern) {
+				return fmt.Errorf(errorMessage, name)
+			}
+		default:
+			if !isValidField(&field, onlyNumbersPattern) {
+				return fmt.Errorf(errorMessage, name)
+			}
+		}
 	}
 	return nil
 }
@@ -122,35 +140,19 @@ type QueueValidator func(*QueueSpec) error
 var (
 	queueValidator = map[QueueType]QueueValidator{}
 )
+
 func RegisterQueueValidator(queueType QueueType, validator QueueValidator) {
 	queueValidator[queueType] = validator
 }
 
-// Validate CloudProvider Level
-func (mp *MetricsProducerSpec) Validate() error {
-	if mp.Queue != nil {
-		queueValidate, ok := queueValidator[mp.Queue.Type]
-		if !ok {
-			return fmt.Errorf("unexpected queue type %v", mp.Queue.Type)
-		}
-		if err := queueValidate(mp.Queue); err != nil {
-			return fmt.Errorf("invalid Metrics Producer, %w", err)
-		}
+// Validate at different level for cloud provider
+func (mp *MetricsProducerSpec) ValidateQueue() error {
+	queueValidate, ok := queueValidator[mp.Queue.Type]
+	if !ok {
+		return fmt.Errorf("unexpected queue type %v", mp.Queue.Type)
 	}
-	if mp.ReservedCapacity != nil {
-		return mp.ReservedCapacity.validate()
-	}
-	return nil
-}
-
-// Validate PendingCapacity
-func (s *PendingCapacitySpec) validate() error {
-	return nil
-}
-// Validate ReservedCapacity
-func (s *ReservedCapacitySpec) validate() error {
-	if len(s.NodeSelector) != 1 {
-		return fmt.Errorf("reserved capacity must refer to exactly one node selector")
+	if err := queueValidate(mp.Queue); err != nil {
+		return fmt.Errorf("invalid Metrics Producer, %w", err)
 	}
 	return nil
 }

--- a/pkg/apis/autoscaling/v1alpha1/metricsproducer_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/metricsproducer_validation.go
@@ -12,9 +12,109 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kubebuilder:webhook:verbs=create;update,path=/validate-autoscaling-karpenter-sh-v1alpha1-metricsproducer,mutating=false,sideEffects=None,failurePolicy=fail,groups=autoscaling.karpenter.sh,resources=metricsproducers,versions=v1alpha1,name=vmetricsproducer.kb.io
+
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Only Validates ScheduledCapacity MetricsProducer right now
+func (m *MetricsProducer) ValidateCreate() error {
+	if err := m.ValidateSchedule(); err != nil  {
+		return err
+	}
+	if m.Spec.ReservedCapacity != nil {
+		return m.Spec.ReservedCapacity.validate()
+	}
+	if m.Spec.PendingCapacity != nil {
+		return m.Spec.PendingCapacity.validate()
+	}
+
+	return nil
+}
+
+func (m *MetricsProducer) ValidateUpdate(old runtime.Object) error {
+	return m.ValidateCreate()
+}
+
+func (m *MetricsProducer) ValidateDelete() error {
+	return nil
+}
+
+func (m *MetricsProducer) ValidateSchedule() error {
+	if m.Spec.Schedule != nil {
+		for _, b := range m.Spec.Schedule.Behaviors {
+			if err := b.Start.IsValidPattern(); err != nil {
+				return fmt.Errorf("start pattern could not be parsed, %w", err)
+			}
+			if err := b.End.IsValidPattern(); err != nil {
+				return fmt.Errorf("end pattern could not be parsed, %w", err)
+			}
+			if b.Replicas < 0 {
+				return fmt.Errorf("behavior.replicas cannot be negative")
+			}
+		}
+	}
+	if m.Spec.Schedule.DefaultReplicas < 0 {
+		return fmt.Errorf("defaultReplicas cannot be negative")
+	}
+	if m.Spec.Schedule.Timezone != nil {
+		if _, err := time.LoadLocation(*m.Spec.Schedule.Timezone); err != nil {
+			return fmt.Errorf("timezone region could not be parsed")
+		}
+	}
+	return nil
+}
+
+// These regex patterns are meant to match to one element at a time
+const (
+	weekdayRegexPattern = "^((sun(day)?|0|7)|(mon(day)?|1)|(tue(sday)?|2)|(wed(nesday)?|3)|(thu(rsday)?|4)|(fri(day)?|5)|(sat(urday)?|6))$"
+	monthRegexPattern = "^((jan(uary)?|1)|(feb(ruary)?|2)|(mar(ch)?|3)|(apr(il)?|4)|(may|5)|(june?|6)|(july?|7)|(aug(ust)?|8)|(sep(tember)?|9)|((oct(ober)?)|(10))|(nov(ember)?|(11))|(dec(ember)?|(12)))$"
+	onlyNumbersPattern = `^\d+$`
+)
+
+func (p *Pattern) IsValidPattern() error {
+	if !isValidField(p.Weekdays, weekdayRegexPattern) {
+		return fmt.Errorf("weekdays field could not be parsed")
+	}
+	if !isValidField(p.Months, monthRegexPattern){
+		return fmt.Errorf("months field could not be parsed")
+	}
+	if !isValidField(p.Days, onlyNumbersPattern){
+		return fmt.Errorf("days field could not be parsed")
+	}
+	if !isValidField(p.Hours, onlyNumbersPattern) {
+		return fmt.Errorf("hours field could not be parsed")
+	}
+	if !isValidField(p.Minutes, onlyNumbersPattern) {
+		return fmt.Errorf("minutes field could not be parsed")
+	}
+	return nil
+}
+
+func isValidField(field *string, regexPattern string) bool {
+	if field == nil {
+		return true
+	}
+	elements := strings.Split(*field, ",")
+	if len(elements) == 0 {
+		return false
+	}
+	for _, elem := range elements {
+		elem = strings.ToLower(strings.Trim(elem, " "))
+		matched, _ := regexp.MatchString(regexPattern, elem)
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
 
 // +kubebuilder:object:generate=false
 type QueueValidator func(*QueueSpec) error
@@ -22,12 +122,11 @@ type QueueValidator func(*QueueSpec) error
 var (
 	queueValidator = map[QueueType]QueueValidator{}
 )
-
 func RegisterQueueValidator(queueType QueueType, validator QueueValidator) {
 	queueValidator[queueType] = validator
 }
 
-// Validate Queue
+// Validate CloudProvider Level
 func (mp *MetricsProducerSpec) Validate() error {
 	if mp.Queue != nil {
 		queueValidate, ok := queueValidator[mp.Queue.Type]
@@ -38,14 +137,8 @@ func (mp *MetricsProducerSpec) Validate() error {
 			return fmt.Errorf("invalid Metrics Producer, %w", err)
 		}
 	}
-	if mp.PendingCapacity != nil {
-		return mp.PendingCapacity.validate()
-	}
 	if mp.ReservedCapacity != nil {
 		return mp.ReservedCapacity.validate()
-	}
-	if mp.Schedule != nil {
-		return mp.Schedule.validate()
 	}
 	return nil
 }
@@ -54,16 +147,10 @@ func (mp *MetricsProducerSpec) Validate() error {
 func (s *PendingCapacitySpec) validate() error {
 	return nil
 }
-
 // Validate ReservedCapacity
 func (s *ReservedCapacitySpec) validate() error {
 	if len(s.NodeSelector) != 1 {
 		return fmt.Errorf("reserved capacity must refer to exactly one node selector")
 	}
-	return nil
-}
-
-// Validate ScheduledCapacity
-func (s *ScheduleSpec) validate() error {
 	return nil
 }

--- a/pkg/apis/autoscaling/v1alpha1/scalablenodegroup_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/scalablenodegroup_validation.go
@@ -12,11 +12,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kubebuilder:webhook:verbs=create;update,path=/validate-autoscaling-karpenter-sh-v1alpha1-scalablenodegroup,mutating=false,sideEffects=None,failurePolicy=fail,groups=autoscaling.karpenter.sh,resources=scalablenodegroups,versions=v1alpha1,name=scalablenodegroup.kb.io
 package v1alpha1
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
+
+var _ webhook.Validator = &ScalableNodeGroup{}
+
+func (sng *ScalableNodeGroup) ValidateCreate() error {
+	return nil
+}
+
+func (sng *ScalableNodeGroup) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+func (sng *ScalableNodeGroup) ValidateDelete() error {
+	return nil
+}
 
 // +kubebuilder:object:generate=false
 type ScalableNodeGroupValidator func(*ScalableNodeGroupSpec) error

--- a/pkg/controllers/horizontalautoscaler/v1alpha1/suite_test.go
+++ b/pkg/controllers/horizontalautoscaler/v1alpha1/suite_test.go
@@ -81,6 +81,9 @@ var _ = Describe("Examples", func() {
 		Expect(err).NotTo(HaveOccurred())
 		ha = &v1alpha1.HorizontalAutoscaler{}
 		sng = &v1alpha1.ScalableNodeGroup{}
+		v1alpha1.RegisterScalableNodeGroupValidator(v1alpha1.AWSEKSNodeGroup, func(sng *v1alpha1.ScalableNodeGroupSpec) error {
+			return nil
+		})
 	})
 
 	AfterEach(func() {

--- a/pkg/metrics/producers/factory.go
+++ b/pkg/metrics/producers/factory.go
@@ -41,9 +41,6 @@ func (f *Factory) For(mp *v1alpha1.MetricsProducer) metrics.Producer {
 		}
 	}
 	if mp.Spec.Queue != nil {
-		if err := mp.Spec.ValidateQueue(); err != nil {
-			return &fake.FakeProducer{WantErr: err}
-		}
 		return &queue.Producer{
 			MetricsProducer: mp,
 			Queue:           f.CloudProviderFactory.QueueFor(mp.Spec.Queue),

--- a/pkg/metrics/producers/factory.go
+++ b/pkg/metrics/producers/factory.go
@@ -34,9 +34,6 @@ type Factory struct {
 }
 
 func (f *Factory) For(mp *v1alpha1.MetricsProducer) metrics.Producer {
-	if err := mp.Spec.Validate(); err != nil {
-		return &fake.FakeProducer{WantErr: err}
-	}
 	if mp.Spec.PendingCapacity != nil {
 		return &pendingcapacity.Producer{
 			MetricsProducer: mp,
@@ -44,6 +41,9 @@ func (f *Factory) For(mp *v1alpha1.MetricsProducer) metrics.Producer {
 		}
 	}
 	if mp.Spec.Queue != nil {
+		if err := mp.Spec.ValidateQueue(); err != nil {
+			return &fake.FakeProducer{WantErr: err}
+		}
 		return &queue.Producer{
 			MetricsProducer: mp,
 			Queue:           f.CloudProviderFactory.QueueFor(mp.Spec.Queue),


### PR DESCRIPTION
- Uses ValidationWebhooks generated by KubeBuilder to validate CRD yamls
- modifies current Queue-Length Metrics Producer validation efforts for cloud provider specific resources
- adds in a field into example docs for current issue (https://github.com/awslabs/karpenter/issues/64)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
