### PR TITLE
Reoriented Capacity CloudProvider around BinPacking

### DIFF
--- a/pkg/cloudprovider/aws/fleet/capacity.go
+++ b/pkg/cloudprovider/aws/fleet/capacity.go
@@ -25,7 +25,6 @@ import (
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
 )
 
 // Capacity cloud provider implementation using AWS Fleet.
@@ -38,7 +37,7 @@ type Capacity struct {
 }
 
 // Create a set of nodes given the constraints.
-func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.CapacityConstraints) ([]*v1.Node, error) {
+func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.CapacityConstraints) (cloudprovider.CapacityPacking, error) {
 	// 1. Select a zone
 	zone, err := c.selectZone(ctx, constraints)
 	if err != nil {
@@ -96,7 +95,13 @@ func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.Capaci
 		return nil, fmt.Errorf("determining nodes, %w", err)
 	}
 	zap.S().Infof("Successfully requested %d nodes", len(nodes))
-	return nodes, nil
+
+	// TODO Implement more sophisticated binpacking.
+	packing := cloudprovider.CapacityPacking{}
+	for _, node := range nodes {
+		packing[node] = constraints.Pods
+	}
+	return packing, nil
 }
 
 // GetTopologyDomains returns a set of supported domains.

--- a/pkg/cloudprovider/fake/capacity.go
+++ b/pkg/cloudprovider/fake/capacity.go
@@ -18,13 +18,12 @@ import (
 	"context"
 
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
-	v1 "k8s.io/api/core/v1"
 )
 
 type Capacity struct {
 }
 
-func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.CapacityConstraints) ([]*v1.Node, error) {
+func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.CapacityConstraints) (cloudprovider.CapacityPacking, error) {
 	return nil, nil
 }
 

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -58,7 +58,7 @@ type NodeGroup interface {
 // Capacity provisions a set of nodes that fulfill a set of constraints.
 type Capacity interface {
 	// Create a set of nodes to fulfill the desired capacity given constraints.
-	Create(context.Context, *CapacityConstraints) ([]*v1.Node, error)
+	Create(context.Context, *CapacityConstraints) (CapacityPacking, error)
 
 	// GetTopologyDomains returns a list of topology domains supported by the
 	// cloud provider for the given key.
@@ -78,15 +78,18 @@ const (
 // CapacityConstraints lets the controller define the desired capacity,
 // avalability zone, architecture for the desired nodes.
 type CapacityConstraints struct {
-	// Topology constrains the topology of the node, e.g. "zone".
-	Topology map[TopologyKey]string
-	// Resources constrains the minimum capacity to provision (e.g. CPU, Memory).
-	Resources v1.ResourceList
+	// Pods is a list of equivalently schedulable pods to be efficiently binpacked.
+	Pods []*v1.Pod
 	// Overhead resources per node from system resources such a kubelet and daemonsets.
 	Overhead v1.ResourceList
+	// Topology constrains the topology of the node, e.g. "zone".
+	Topology map[TopologyKey]string
 	// Architecture constrains the underlying hardware architecture.
 	Architecture Architecture
 }
+
+// CapacityPacking is a solution to packing pods onto nodes given constraints.
+type CapacityPacking map[*v1.Node][]*v1.Pod
 
 // Architecture constrains the underlying node's compilation architecture.
 type Architecture string


### PR DESCRIPTION
```
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317115.3636768,"msg":"Allocating 4 pending pods from 4 constraint groups"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317116.7961228,"msg":"Successfully discovered subnets in 3 zones for cluster etarn-dev"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317116.8354862,"msg":"Successfully discovered launch template Karpenter-etarn-dev for cluster etarn-dev"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317118.7805374,"msg":"Successfully requested 1 nodes"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317118.7995632,"msg":"Successfully bound pod default/pause-5d968bbb58-lc88c to node ip-192-168-136-52.us-west-2.compute.internal"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317120.8496006,"msg":"Retrying DescribeInstances due to eventual consistency: fleet created, but instances not yet found."}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317121.6599963,"msg":"Successfully requested 1 nodes"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317121.6878824,"msg":"Successfully bound pod default/pause-5d968bbb58-nmw7n to node ip-192-168-138-151.us-west-2.compute.internal"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317123.5314267,"msg":"Retrying DescribeInstances due to eventual consistency: fleet created, but instances not yet found."}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317124.6290648,"msg":"Successfully requested 1 nodes"}
karpenter-6fc6f46667-stjzm manager {"level":"error","ts":1612317124.6469412,"msg":"Controller failed to reconcile kind: Provisioner err: failed to allocate 4 pods, binding pods to node, binding pod, Operation cannot be fulfilled on pods/binding \"pause-5d968bbb58-qnwbg\": pod pause-5d968bbb58-qnwbg is already assigned to node \"ip-192-168-136-52.us-west-2.compute.internal\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.7.0-alpha.3/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.7.0-alpha.3/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.7.0-alpha.3/pkg/internal/controller/controller.go:198\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\tk8s.io/apimachinery@v0.19.3/pkg/util/wait/wait.go:99"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317124.6651247,"msg":"Allocating 0 pending pods from 0 constraint groups"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317124.6824012,"msg":"Allocating 0 pending pods from 0 constraint groups"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317184.6652062,"msg":"Allocating 1 pending pods from 1 constraint groups"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317186.8216467,"msg":"Successfully requested 1 nodes"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317186.8397038,"msg":"Successfully bound pod default/pause-5d968bbb58-lhb2z to node ip-192-168-153-13.us-west-2.compute.internal"}
karpenter-6fc6f46667-stjzm manager {"level":"info","ts":1612317246.850394,"msg":"Allocating 0 pending pods from 0 constraint groups"}
```