### PR TITLE
Bottlerocket support

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -38,7 +38,7 @@ make codegen                     # Create auto-generated YAML files.
 
 ### Build and Deploy
 ```
-make all                                  # build and test code
+make dev                                  # build and test code
 make apply                                # deploy local changes to cluster
 CLOUD_PROVIDER=<YOUR_PROVIDER> make apply # deploy for your cloud provider
 ```

--- a/pkg/cloudprovider/aws/fleet/instanceprofile.go
+++ b/pkg/cloudprovider/aws/fleet/instanceprofile.go
@@ -60,7 +60,7 @@ func (p *InstanceProfileProvider) getInstanceProfile(ctx context.Context, cluste
 		InstanceProfileName: aws.String(KarpenterNodeInstanceProfileName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("retriving instance profile %s, %w", IAMInstanceProfileName, err)
+		return nil, fmt.Errorf("retriving instance profile %s, %w", KarpenterNodeInstanceProfileName, err)
 	}
 	for _, role := range output.InstanceProfile.Roles {
 		if err := p.addToAWSAuthConfigmap(role); err != nil {

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -36,13 +36,13 @@ import (
 
 const (
 	launchTemplateNameFormat = "Karpenter-%s"
-	bottlerocketUserdata     = `
+	bottlerocketUserData     = `
 [settings.kubernetes]
 api-server = "{{.Endpoint}}"
 cluster-certificate = "{{.CABundle}}"
 cluster-name = "{{.Name}}"
 [settings.kubernetes.node-labels]
-karpenter-sh-provisioned = true
+karpenter-sh-provisioned = "true"
 `
 )
 
@@ -157,7 +157,7 @@ func (p *LaunchTemplateProvider) getAMIID(ctx context.Context) (*string, error) 
 }
 
 func (p *LaunchTemplateProvider) getUserData(cluster *v1alpha1.ClusterSpec) (*string, error) {
-	t := template.Must(template.New("userdata").Parse(bottlerocketUserdata))
+	t := template.Must(template.New("userData").Parse(bottlerocketUserData))
 	var userData bytes.Buffer
 	if err := t.Execute(&userData, cluster); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -152,7 +152,7 @@ func (p *LaunchTemplateProvider) getAMIID(ctx context.Context) (*string, error) 
 		Name: aws.String(fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version)),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("ssm get parameter, %w", err)
+		return nil, fmt.Errorf("getting ssm parameter, %w", err)
 	}
 	return paramOutput.Parameter.Value, nil
 }

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -39,7 +39,7 @@ const (
 	IAMInstanceProfileName   = "KarpenterNodeRole"
 	bottleRocketUserData     = `
 [settings.kubernetes]
-api-server = "{{Endpoint}}"
+api-server = "{{.Endpoint}}"
 cluster-certificate = "{{.CABundle}}"
 cluster-name = "{{.Name}}"
 [settings.kubernetes.node-labels]

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -170,5 +170,5 @@ func (p *LaunchTemplateProvider) kubeServerVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.%s", version.Major, strings.TrimSuffix(version.Minor, "+")), err
+	return fmt.Sprintf("%s.%s", version.Major, strings.TrimSuffix(version.Minor, "+")), nil
 }

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -43,7 +43,7 @@ api-server = "{{.Endpoint}}"
 cluster-certificate = "{{.CABundle}}"
 cluster-name = "{{.Name}}"
 [settings.kubernetes.node-labels]
-"karpenter.sh/provisioned" = "true"
+karpenter.sh/provisioned = true
 `
 )
 

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -39,9 +39,9 @@ const (
 	IAMInstanceProfileName   = "KarpenterNodeRole"
 	bottleRocketUserData     = `
 [settings.kubernetes]
-api-server = "${.Endpoint}"
-cluster-certificate = "${.CABundle}"
-cluster-name = "${.Name}"
+api-server = "{{Endpoint}}"
+cluster-certificate = "{{.CABundle}}"
+cluster-name = "{{.Name}}"
 [settings.kubernetes.node-labels]
 "karpenter.sh/provisioned" = "true"
 `

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -143,12 +143,12 @@ func (p *LaunchTemplateProvider) getSecurityGroupIds(ctx context.Context, cluste
 	return securityGroupIds, nil
 }
 
-func (p *LaunchTemplateProvider) getAMIID(context context.Context) (*string, error) {
+func (p *LaunchTemplateProvider) getAMIID(ctx context.Context) (*string, error) {
 	version, err := p.kubeServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("kube server version, %w", err)
 	}
-	paramOutput, err := p.ssm.GetParameter(&ssm.GetParameterInput{
+	paramOutput, err := p.ssm.GetParameterWithContext(ctx, &ssm.GetParameterInput{
 		Name: aws.String(fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version)),
 	})
 	if err != nil {
@@ -168,5 +168,8 @@ func (p *LaunchTemplateProvider) getUserData(cluster *v1alpha1.ClusterSpec) (*st
 
 func (p *LaunchTemplateProvider) kubeServerVersion() (string, error) {
 	version, err := p.clientSet.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf("%s.%s", version.Major, strings.TrimSuffix(version.Minor, "+")), err
 }

--- a/pkg/cloudprovider/aws/fleet/launchtemplate.go
+++ b/pkg/cloudprovider/aws/fleet/launchtemplate.go
@@ -42,7 +42,7 @@ api-server = "{{.Endpoint}}"
 cluster-certificate = "{{.CABundle}}"
 cluster-name = "{{.Name}}"
 [settings.kubernetes.node-labels]
-karpenter-sh-provisioned = "true"
+"karpenter.sh/provisioned" = "true"
 `
 )
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/karpenter/issues/230

*Description of changes:*

This change switches from the EKS Optimized AMI to the Bottlerocket EKS AMI. It doesn't add any new functionality beyond that, (e.g., it does not include the ability to have custom UserData or switch between the two forms of AMI, which should be a separate issue.) Tested by hand on a cluster by cordoning existing nodes and ensuring a BR instance spins up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
