### PR TITLE
Fixed Error in reallocator for cloudprovider

### DIFF
--- a/pkg/controllers/provisioning/v1alpha1/reallocator/controller.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocator/controller.go
@@ -54,7 +54,7 @@ func (c *Controller) Name() string {
 func NewController(kubeClient client.Client, cloudProvider cloudprovider.Factory) *Controller {
 	return &Controller{
 		filter:        &Filter{kubeClient: kubeClient},
-		terminator:    &Terminator{kubeClient: kubeClient},
+		terminator:    &Terminator{kubeClient: kubeClient, cloudprovider: cloudProvider},
 		cloudProvider: cloudProvider,
 	}
 }

--- a/pkg/controllers/provisioning/v1alpha1/reallocator/terminate.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocator/terminate.go
@@ -62,7 +62,7 @@ func (t *Terminator) DeleteNodes(ctx context.Context, nodes []*v1.Node, spec *v1
 	if err != nil {
 		return fmt.Errorf("terminating %d cloudprovider instances, %w", len(nodes), err)
 	}
-	zap.S().Infof("Succesfully terminated %d instances", len(nodes))
+	zap.S().Infof("Terminating %d instances", len(nodes))
 
 	return nil
 }


### PR DESCRIPTION
Fixed an error in reallocator where cloudprovider was not defined, resulting in inability to delete nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
