### PR TITLE
Added TTL reevaluation logic for reallocation

### DIFF
--- a/pkg/apis/provisioning/v1alpha1/doc.go
+++ b/pkg/apis/provisioning/v1alpha1/doc.go
@@ -41,7 +41,10 @@ var (
 	// These Keys are used for label matching
 	ProvisionerNameLabelKey      = SchemeGroupVersion.Group + "/name"
 	ProvisionerNamespaceLabelKey = SchemeGroupVersion.Group + "/namespace"
-	ProvisionerTTLKey            = SchemeGroupVersion.Group + "/ttl"
+	ProvisionerUnderutilizedKey  = SchemeGroupVersion.Group + "/underutilized"
+
+	// ProvisionerTTLKey is used for annotation matching
+	ProvisionerTTLKey = SchemeGroupVersion.Group + "/ttl"
 )
 
 const (

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/annotate.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/annotate.go
@@ -1,0 +1,80 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reallocation
+
+import (
+	"context"
+	"fmt"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
+	utilsnode "github.com/awslabs/karpenter/pkg/utils/node"
+	"github.com/awslabs/karpenter/pkg/utils/ptr"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type Annotator struct {
+	kubeClient client.Client
+}
+
+// MarkUnderutilized takes in a list of underutilized nodes and adds TTL to them
+func (a *Annotator) MarkUnderutilized(ctx context.Context, nodes []*v1.Node) error {
+	for _, node := range nodes {
+		persisted := node.DeepCopy()
+		node.Labels[v1alpha1.ProvisionerUnderutilizedKey] = "true"
+		node.Annotations[v1alpha1.ProvisionerTTLKey] = time.Now().Add(300 * time.Second).Format(time.RFC3339)
+		if err := a.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
+			return fmt.Errorf("patching node %s, %w", node.Name, err)
+		}
+		zap.S().Debugf("Added TTL and label to underutilized node %s", node.Name)
+	}
+	return nil
+}
+
+// ClearUnderutilized takes in a list of nodes labeled underutilized and removes TTL if there is sufficient resource usage
+func (a *Annotator) ClearUnderutilized(ctx context.Context, nodes []*v1.Node) error {
+	for _, node := range nodes {
+		pods := &v1.PodList{}
+		if err := a.kubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+			return fmt.Errorf("listing pods on node %s, %w", node.Name, err)
+		}
+
+		if !utilsnode.IsUnderutilized(ptr.PodListToSlice(pods)) {
+			persisted := node.DeepCopy()
+			delete(node.Labels, v1alpha1.ProvisionerUnderutilizedKey)
+			delete(node.Annotations, v1alpha1.ProvisionerTTLKey)
+			if err := a.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
+				return fmt.Errorf("patching node %s, %w", node.Name, err)
+			} else {
+				zap.S().Debugf("Removed TTL from node %s", node.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// CordonNodes takes in a list of expired nodes as input and cordons them
+func (a *Annotator) CordonNodes(ctx context.Context, nodes []*v1.Node) error {
+	for _, node := range nodes {
+		persisted := node.DeepCopy()
+		node.Spec.Unschedulable = true
+		if err := a.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
+			return fmt.Errorf("patching node %s, %w", node.Name, err)
+		}
+		zap.S().Debugf("Cordoned node %s", node.Name)
+	}
+	return nil
+}

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/terminate.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/terminate.go
@@ -22,38 +22,11 @@ import (
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 type Terminator struct {
 	kubeClient    client.Client
 	cloudprovider cloudprovider.Factory
-}
-
-// AddTTLs takes in a list of underutilized nodes and adds TTL to them
-func (t *Terminator) AddTTLs(ctx context.Context, nodes []*v1.Node) error {
-	for _, node := range nodes {
-		persisted := node.DeepCopy()
-		node.Annotations[v1alpha1.ProvisionerTTLKey] = time.Now().Add(300 * time.Second).Format(time.RFC3339)
-		if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
-			return fmt.Errorf("patching node, %w", err)
-		}
-		zap.S().Debugf("Added TTL to nodes %s", node.Name)
-	}
-	return nil
-}
-
-// CordonNodes takes in a list of expired nodes as input and cordons them
-func (t *Terminator) CordonNodes(ctx context.Context, nodes []*v1.Node) error {
-	for _, node := range nodes {
-		persisted := node.DeepCopy()
-		node.Spec.Unschedulable = true
-		if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
-			return fmt.Errorf("patching node %s, %w", node.Name, err)
-		}
-		zap.S().Debugf("Cordoned node %s", node.Name)
-	}
-	return nil
 }
 
 // DeleteNodes will use a cloudprovider implementation to delete a set of nodes

--- a/pkg/utils/node/predicates.go
+++ b/pkg/utils/node/predicates.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
+	"github.com/awslabs/karpenter/pkg/utils/scheduling"
 	v1 "k8s.io/api/core/v1"
 	"time"
 )
@@ -39,4 +40,15 @@ func IsPastTTL(node *v1.Node) bool {
 		return false
 	}
 	return time.Now().After(ttlTime)
+}
+
+// TODO: implement underutilized function (some generalized predicate)
+func IsUnderutilized(pods []*v1.Pod) bool {
+	counter := 0
+	for _, pod := range pods {
+		if !scheduling.IsOwnedByDaemonSet(pod) {
+			counter += 1
+		}
+	}
+	return counter == 0
 }

--- a/pkg/utils/ptr/ptr.go
+++ b/pkg/utils/ptr/ptr.go
@@ -23,3 +23,19 @@ func Pod(pod v1.Pod) *v1.Pod {
 func Node(node v1.Node) *v1.Node {
 	return &node
 }
+
+func NodeListToSlice(nodes *v1.NodeList) []*v1.Node {
+	nodePointers := []*v1.Node{}
+	for _, node := range nodes.Items {
+		nodePointers = append(nodePointers, Node(node))
+	}
+	return nodePointers
+}
+
+func PodListToSlice(pods *v1.PodList) []*v1.Pod {
+	podPointers := []*v1.Pod{}
+	for _, pod := range pods.Items {
+		podPointers = append(podPointers, Pod(pod))
+	}
+	return podPointers
+}


### PR DESCRIPTION
- Nodes that have a TTL set due to underutilization are now reevaluated in case pods or other resources begin using that pass the threshold (0 non-daemon pods) right now

Logical Flow: (asterisked fields are added in this PR)
- Node is deemed underutilized
- Node labeled underutilized*
- Add TTL to underutilized nodes
- Get Nodes labeled underutilized and remove TTL if they have sufficient utilization*
- Get expired nodes (past TTL)
- Cordon expired Nodes
- Delete cordoned Nodes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
