### PR TITLE
ResourceList Pointer error fix

### DIFF
--- a/pkg/controllers/provisioning/v1alpha1/allocation/constraints.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/constraints.go
@@ -153,11 +153,12 @@ func (c *Constraints) getNodeOverhead(ctx context.Context, pod *v1.Pod, node *v1
 	}
 
 	// 3. Compute overhead
-	overhead := v1.ResourceList{v1.ResourceCPU: resource.Quantity{}, v1.ResourceMemory: resource.Quantity{}}
+	cpuTotal := &resource.Quantity{}
+	memoryTotal := &resource.Quantity{}
 	for _, daemonSet := range daemonSets {
 		resources := scheduling.GetResources(&daemonSet.Spec.Template.Spec)
-		overhead.Cpu().Add(*resources.Cpu())
-		overhead.Memory().Add(*resources.Memory())
+		cpuTotal.Add(*resources.Cpu())
+		memoryTotal.Add(*resources.Memory())
 	}
-	return overhead, nil
+	return v1.ResourceList{v1.ResourceCPU: *cpuTotal, v1.ResourceMemory: *memoryTotal}, nil
 }

--- a/pkg/utils/scheduling/scheduling.go
+++ b/pkg/utils/scheduling/scheduling.go
@@ -49,16 +49,21 @@ func FailedToSchedule(pod *v1.Pod) bool {
 
 // GetResources returns the total resources of the pod.
 func GetResources(pod *v1.PodSpec) v1.ResourceList {
-	resources := v1.ResourceList{v1.ResourceCPU: resource.Quantity{}, v1.ResourceMemory: resource.Quantity{}}
+	cpuTotal := &resource.Quantity{}
+	memoryTotal := &resource.Quantity{}
+
 	for _, container := range pod.Containers {
 		if cpu := container.Resources.Requests.Cpu(); cpu != nil {
-			resources.Cpu().Add(*cpu)
+			cpuTotal.Add(*cpu)
 		}
 		if memory := container.Resources.Requests.Memory(); memory != nil {
-			resources.Memory().Add(*memory)
+			memoryTotal.Add(*memory)
 		}
 	}
-	return resources
+	return v1.ResourceList{
+		v1.ResourceCPU:    *cpuTotal,
+		v1.ResourceMemory: *memoryTotal,
+	}
 }
 
 // IsSchedulable returns true if the pod can schedule to the node


### PR DESCRIPTION
*Issue #, if available:*

Since a ResourceList is a `map[ResourceName]resource.Quantity`, the Add function does not work for values of this map, since we pass in a direct reference, not a pointer. 

GetResources used to return 0 values of quantities, but now returns accurate values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
