### PR TITLE
Fix wrong remaining pods value 

### DIFF
--- a/pkg/cloudprovider/aws/fleet/packing/packing.go
+++ b/pkg/cloudprovider/aws/fleet/packing/packing.go
@@ -87,12 +87,12 @@ func (p *podPacker) getNodeCapacities() []*nodeCapacity {
 func (p *podPacker) packWithLargestPod(pods []*v1.Pod) (*Packing, []*v1.Pod) {
 	bestPackedPods := []*v1.Pod{}
 	bestCapacities := []*nodeCapacity{}
-	remainingPods := []*v1.Pod{}
+	remainingPods := pods
 	// TODO reserve (Kubelet+ daemon sets) overhead for instance types
 	// TODO count number of pods created on an instance type
 	for _, nc := range p.getNodeCapacities() {
 		// check how many pods we can fit with the available capacity
-		packedPods, leftOvers := p.packPodsForCapacity(nc, pods)
+		packedPods, unpackedPods := p.packPodsForCapacity(nc, pods)
 		if len(packedPods) == 0 {
 			continue
 		}
@@ -104,7 +104,7 @@ func (p *podPacker) packWithLargestPod(pods []*v1.Pod) (*Packing, []*v1.Pod) {
 			// If pods packed are more than compared to what we got in last
 			// iteration, consider using this instance type
 			bestPackedPods = packedPods
-			remainingPods = leftOvers
+			remainingPods = unpackedPods
 			bestCapacities = []*nodeCapacity{nc}
 		}
 	}

--- a/pkg/cloudprovider/aws/fleet/packing/packing.go
+++ b/pkg/cloudprovider/aws/fleet/packing/packing.go
@@ -87,13 +87,12 @@ func (p *podPacker) getNodeCapacities() []*nodeCapacity {
 func (p *podPacker) packWithLargestPod(pods []*v1.Pod) (*Packing, []*v1.Pod) {
 	bestPackedPods := []*v1.Pod{}
 	bestCapacities := []*nodeCapacity{}
-	var packedPods []*v1.Pod
-	remainingPods := pods
+	remainingPods := []*v1.Pod{}
 	// TODO reserve (Kubelet+ daemon sets) overhead for instance types
 	// TODO count number of pods created on an instance type
 	for _, nc := range p.getNodeCapacities() {
 		// check how many pods we can fit with the available capacity
-		packedPods, remainingPods = p.packPodsForCapacity(nc, pods)
+		packedPods, leftOvers := p.packPodsForCapacity(nc, pods)
 		if len(packedPods) == 0 {
 			continue
 		}
@@ -105,6 +104,7 @@ func (p *podPacker) packWithLargestPod(pods []*v1.Pod) (*Packing, []*v1.Pod) {
 			// If pods packed are more than compared to what we got in last
 			// iteration, consider using this instance type
 			bestPackedPods = packedPods
+			remainingPods = leftOvers
 			bestCapacities = []*nodeCapacity{nc}
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Problem: we check all the node capacities, if smallest node is checked in the end `remainingPods` gets updated but the `bestPackedPods` already contains higher number of packed pods. So when this function returns it `bestPackedPods` which contains the highest number of packed pods but `remainingPods` contains pods left over for the node with a smaller capacity.

This fix will update the `remainingPods` to the right set of pods everytime we update `bestPackedPods`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
