### PR TITLE
Added validation for provisioners

### DIFF
--- a/pkg/apis/provisioning/v1alpha1/provisioner_defaults.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner_defaults.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kubebuilder:webhook:path=/mutate-provisioning-karpenter-sh-v1alpha1-provisioner,mutating=true,sideEffects=None,failurePolicy=fail,groups=provisioning.karpenter.sh,resources=provisioners,verbs=create;update,versions=v1alpha1,name=mprovisioner.kb.io
+// +kubebuilder:webhook:path=/mutate-provisioning-karpenter-sh-v1alpha1-provisioner,mutating=true,sideEffects=None,failurePolicy=fail,groups=provisioning.karpenter.sh,resources=provisioners,verbs=create;update,versions=v1alpha1,name=mutation.provisioning.karpenter.sh
 
 package v1alpha1
 

--- a/pkg/apis/provisioning/v1alpha1/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner_validation.go
@@ -12,25 +12,122 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kubebuilder:webhook:path=/validate-provisioning-karpenter-sh-v1alpha1-provisioner,mutating=false,sideEffects=None,failurePolicy=fail,groups=provisioning.karpenter.sh,resources=provisioners,verbs=create;update,versions=v1alpha1,name=validation.provisioning.karpenter.sh
+
 package v1alpha1
 
 import (
+	"fmt"
+
+	"github.com/awslabs/karpenter/pkg/utils/functional"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// +kubebuilder:webhook:path=/validate-provisioning-karpenter-sh-v1alpha1-provisioner,mutating=false,sideEffects=None,failurePolicy=fail,groups=provisioning.karpenter.sh,resources=provisioners,verbs=create;update,versions=v1alpha1,name=vprovisioner.kb.io
-
 var _ webhook.Validator = &Provisioner{}
 
-func (r *Provisioner) ValidateCreate() error {
+func (p *Provisioner) ValidateCreate() error {
+	return p.validate()
+}
+
+func (p *Provisioner) ValidateUpdate(old runtime.Object) error {
+	return p.validate()
+}
+
+func (p *Provisioner) ValidateDelete() error {
 	return nil
 }
 
-func (r *Provisioner) ValidateUpdate(old runtime.Object) error {
+func (p *Provisioner) validate() error {
+	return functional.AllSucceed(
+		p.validateClusterSpec,
+		p.validateRestrictedLabels,
+		p.validateArchitecture,
+		p.validateOperatingSystem,
+	)
+}
+
+func (p *Provisioner) validateClusterSpec() error {
+	if p.Spec.Cluster == nil {
+		return fmt.Errorf("spec.cluster must be defined")
+	}
+	if len(p.Spec.Cluster.Name) == 0 {
+		return fmt.Errorf("spec.cluster.name cannot be empty")
+	}
+	if len(p.Spec.Cluster.Endpoint) == 0 {
+		return fmt.Errorf("spec.cluster.endpoint cannot be empty")
+	}
+	if len(p.Spec.Cluster.CABundle) == 0 {
+		return fmt.Errorf("spec.cluster.caBundle cannot be empty")
+	}
 	return nil
 }
 
-func (r *Provisioner) ValidateDelete() error {
+func (p *Provisioner) validateRestrictedLabels() error {
+	for label := range p.Spec.Labels {
+		for _, restricted := range RestrictedLabels {
+			if restricted == label {
+				return fmt.Errorf("spec.labels contains restricted label %s", label)
+			}
+		}
+	}
 	return nil
+}
+
+func (p *Provisioner) validateArchitecture() error {
+	if p.Spec.Architecture == nil {
+		return nil
+	}
+	for _, architecture := range SupportedArchitectures {
+		if architecture == Architecture(*p.Spec.Architecture) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported architecture %s", *p.Spec.Architecture)
+}
+
+func (p *Provisioner) validateOperatingSystem() error {
+	if p.Spec.OperatingSystem == nil {
+		return nil
+	}
+	for _, operatingSystem := range SupportedOperatingSystems {
+		if operatingSystem == OperatingSystem(*p.Spec.OperatingSystem) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported architecture %s", *p.Spec.OperatingSystem)
+}
+
+var SupportedArchitectures []Architecture
+
+// AddSupportedArchitectures is populated by cloud providers.
+func AddSupportedArchitectures(architecture ...Architecture) {
+	SupportedArchitectures = append(SupportedArchitectures, architecture...)
+}
+
+var SupportedOperatingSystems []OperatingSystem
+
+// AddSupportedOperatingSystems is populated by cloud providers.
+func AddSupportedOperatingSystems(architecture ...OperatingSystem) {
+	SupportedOperatingSystems = append(SupportedOperatingSystems, architecture...)
+}
+
+var RestrictedLabels []string
+
+// AddRestrictedLabels is populated by cloud providers.
+func AddRestrictedLabels(key ...string) {
+	RestrictedLabels = append(RestrictedLabels, key...)
+}
+
+func init() {
+	AddRestrictedLabels(
+		ArchitectureLabelKey,
+		OperatingSystemLabelKey,
+		ProvisionerNameLabelKey,
+		ProvisionerNamespaceLabelKey,
+		ProvisionerPhaseLabel,
+		ProvisionerTTLKey,
+		ZoneLabelKey,
+		InstanceTypeLabelKey,
+	)
 }

--- a/pkg/apis/provisioning/v1alpha1/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha1/suite_test.go
@@ -1,0 +1,108 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Pallinder/go-randomdata"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Provisioning",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = Describe("Validation", func() {
+	var provisioner *Provisioner
+
+	BeforeEach(func() {
+		provisioner = &Provisioner{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.ToLower(randomdata.SillyName()),
+			},
+			Spec: ProvisionerSpec{
+				Cluster: &ClusterSpec{
+					Name:     "test-cluster",
+					Endpoint: "https://test-cluster",
+					CABundle: "dGVzdC1jbHVzdGVyCg==",
+				},
+			},
+		}
+	})
+
+	It("should fail for empty cluster specification", func() {
+		for _, cluster := range []*ClusterSpec{
+			nil,
+			{Endpoint: "https://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
+			{Name: "test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
+			{Name: "test-cluster", Endpoint: "https://test-cluster"},
+		} {
+			provisioner.Spec.Cluster = cluster
+			Expect(provisioner.ValidateCreate()).ToNot(Succeed())
+		}
+	})
+
+	It("should fail for restricted labels", func() {
+		for _, label := range RestrictedLabels {
+			provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
+			Expect(provisioner.ValidateCreate()).ToNot(Succeed())
+		}
+	})
+
+	It("should fail for invalid architecture", func() {
+		// Nil is ok
+		Expect(provisioner.ValidateCreate()).To(Succeed())
+
+		// Not supported (unregistered)
+		provisioner.Spec.Architecture = &ArchitectureAmd64
+		Expect(provisioner.ValidateCreate()).ToNot(Succeed())
+
+		// Supported (registered)
+		for _, architecture := range []*Architecture{
+			&ArchitectureAmd64,
+			&ArchitectureArm64,
+		} {
+			AddSupportedArchitectures(*architecture)
+			provisioner.Spec.Architecture = architecture
+			Expect(provisioner.ValidateCreate()).To(Succeed())
+		}
+	})
+
+	It("should fail for invalid operating system", func() {
+		// Nil is ok
+		Expect(provisioner.ValidateCreate()).To(Succeed())
+
+		// Not supported (unregistered)
+		provisioner.Spec.OperatingSystem = &OperatingSystemLinux
+		Expect(provisioner.ValidateCreate()).ToNot(Succeed())
+
+		// Supported (registered)
+		for _, operatingSystem := range []*OperatingSystem{
+			&OperatingSystemLinux,
+		} {
+			AddSupportedOperatingSystems(*operatingSystem)
+			provisioner.Spec.OperatingSystem = operatingSystem
+			Expect(provisioner.ValidateCreate()).To(Succeed())
+		}
+	})
+})

--- a/pkg/cloudprovider/aws/fleet/capacity.go
+++ b/pkg/cloudprovider/aws/fleet/capacity.go
@@ -87,3 +87,13 @@ func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.Constr
 func (c *Capacity) Delete(ctx context.Context, nodes []*v1.Node) error {
 	return c.instanceProvider.Terminate(ctx, nodes)
 }
+
+func init() {
+	v1alpha1.AddSupportedArchitectures(
+		v1alpha1.ArchitectureAmd64,
+		v1alpha1.ArchitectureArm64,
+	)
+	v1alpha1.AddSupportedOperatingSystems(
+		v1alpha1.OperatingSystemLinux,
+	)
+}

--- a/pkg/cloudprovider/aws/test/allocator_test.go
+++ b/pkg/cloudprovider/aws/test/allocator_test.go
@@ -12,12 +12,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fleet
+package test
 
 import (
 	"context"
 	"strings"
-	"testing"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,13 +36,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
-
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Provisioner", []Reporter{printer.NewlineReporter{}})
-}
 
 var controller *allocation.Controller
 var fakeEC2API *fake.EC2API
@@ -90,7 +83,7 @@ var _ = Describe("Allocation", func() {
 		prov := &v1alpha1.Provisioner{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name},
 			Spec: v1alpha1.ProvisionerSpec{
-				Cluster: &v1alpha1.ClusterSpec{Name: "test-cluster"},
+				Cluster: &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
 			},
 		}
 		pod := test.PodWith(test.PodOptions{
@@ -135,7 +128,7 @@ var _ = Describe("Allocation", func() {
 		prov := &v1alpha1.Provisioner{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name},
 			Spec: v1alpha1.ProvisionerSpec{
-				Cluster:     &v1alpha1.ClusterSpec{Name: "test-cluster"},
+				Cluster:     &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
 				Constraints: v1alpha1.Constraints{Zones: []string{"test-zone-1a", "test-zone-1b"}},
 			},
 		}
@@ -177,7 +170,7 @@ var _ = Describe("Allocation", func() {
 		prov := &v1alpha1.Provisioner{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name},
 			Spec: v1alpha1.ProvisionerSpec{
-				Cluster:     &v1alpha1.ClusterSpec{Name: "test-cluster"},
+				Cluster:     &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
 				Constraints: v1alpha1.Constraints{Zones: []string{"test-zone-1a", "test-zone-1b"}},
 			},
 		}

--- a/pkg/cloudprovider/aws/test/suite_test.go
+++ b/pkg/cloudprovider/aws/test/suite_test.go
@@ -12,8 +12,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package environment
+package test
 
-// TODO integration tests
-type Remote struct {
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "AWS Cloud Provider", []Reporter{printer.NewlineReporter{}})
 }

--- a/pkg/cloudprovider/aws/test/validation_test.go
+++ b/pkg/cloudprovider/aws/test/validation_test.go
@@ -1,0 +1,63 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"strings"
+
+	"github.com/Pallinder/go-randomdata"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Validation", func() {
+	var provisioner *v1alpha1.Provisioner
+
+	BeforeEach(func() {
+		provisioner = &v1alpha1.Provisioner{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.ToLower(randomdata.SillyName()),
+			},
+			Spec: v1alpha1.ProvisionerSpec{
+				Cluster: &v1alpha1.ClusterSpec{
+					Name:     "test-cluster",
+					Endpoint: "https://test-cluster",
+					CABundle: "dGVzdC1jbHVzdGVyCg==",
+				},
+			},
+		}
+	})
+
+	It("should support architectures", func() {
+		for _, architecture := range []*v1alpha1.Architecture{
+			&v1alpha1.ArchitectureAmd64,
+			&v1alpha1.ArchitectureArm64,
+		} {
+			provisioner.Spec.Architecture = architecture
+			Expect(provisioner.ValidateCreate()).To(Succeed())
+		}
+	})
+
+	It("should support operating systems", func() {
+		for _, operatingSystem := range []*v1alpha1.OperatingSystem{
+			&v1alpha1.OperatingSystemLinux,
+		} {
+			provisioner.Spec.OperatingSystem = operatingSystem
+			Expect(provisioner.ValidateCreate()).To(Succeed())
+		}
+	})
+})

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -85,7 +85,7 @@ func (c *GenericController) Reconcile(ctx context.Context, req reconcile.Request
 	// 2. Copy object for merge patch base
 	persisted := resource.DeepCopyObject()
 	// 3. Validate
-	if err := c.For().ValidateCreate(); err != nil {
+	if err := resource.ValidateCreate(); err != nil {
 		resource.StatusConditions().MarkFalse(v1alpha1.Active, "could not validate kind %s, %s",
 			resource.GetObjectKind().GroupVersionKind().Kind, err.Error())
 		zap.S().Errorf("Controller failed to validate kind %s, %s",

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/awslabs/karpenter/pkg/apis"
 	"github.com/awslabs/karpenter/pkg/utils/log"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
-	functional "github.com/awslabs/karpenter/pkg/utils/functional"
+	"github.com/awslabs/karpenter/pkg/utils/functional"
 	"github.com/awslabs/karpenter/pkg/utils/ptr"
 	"github.com/awslabs/karpenter/pkg/utils/scheduling"
 	"go.uber.org/zap"

--- a/pkg/controllers/provisioning/v1alpha1/allocation/suite_test.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/suite_test.go
@@ -76,7 +76,12 @@ var _ = Describe("Allocation", func() {
 
 	Context("Reconcilation", func() {
 		It("should provision nodes for unconstrained pods", func() {
-			p := &v1alpha1.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name}}
+			p := &v1alpha1.Provisioner{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name},
+				Spec: v1alpha1.ProvisionerSpec{
+					Cluster: &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
+				},
+			}
 			pods := []*v1.Pod{
 				test.PodWith(test.PodOptions{
 					Namespace:  ns.Name,
@@ -105,7 +110,12 @@ var _ = Describe("Allocation", func() {
 
 		It("should provision nodes for pods with supported node selectors", func() {
 			// Setup
-			p := &v1alpha1.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name}}
+			p := &v1alpha1.Provisioner{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName()), Namespace: ns.Name},
+				Spec: v1alpha1.ProvisionerSpec{
+					Cluster: &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
+				},
+			}
 			coschedulable := []client.Object{
 				// Unconstrained
 				test.PodWith(test.PodOptions{

--- a/pkg/utils/functional/functional.go
+++ b/pkg/utils/functional/functional.go
@@ -19,6 +19,7 @@ import (
 	"math"
 
 	"github.com/awslabs/karpenter/pkg/utils/log"
+	"go.uber.org/multierr"
 )
 
 // GreaterThanInt32 returns values greater than the target value
@@ -137,10 +138,9 @@ type Errorable func() error
 
 // AllSucceed returns nil if all errorables return nil, otherwise returns the first error.
 func AllSucceed(errorables ...func() error) error {
+	var err error
 	for _, errorable := range errorables {
-		if err := errorable(); err != nil {
-			return err
-		}
+		err = multierr.Append(err, errorable())
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
1. Support for provider specific validation (i.e. supported OS/Arch)
2. Support for common validation (i.e. restricted labels, cluster spec)
```
Error from server (spec.labels contains restricted label kubernetes.io/arch): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"provisioning.karpenter.sh/v1alpha1\",\"kind\":\"Provisioner\",\"metadata\":{\"annotations\":{},\"name\":\"default\",\"namespace\":\"default\"},\"spec\":{\"cluster\":{\"caBundle\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ESXhNVEl3TURVeE0xb1hEVE14TURJd09USXdNRFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTEUxCjVlN0hoZXgvMHRZNlRmME1kam9HZ1lpRDFQb1pxUHphMUdkTDk0aVpmdm9xMC95d0QzeVhSeCtNbXY3aUJnRGwKQWw2cmRzNENJSXRKeFZ2eXZyQmFFWXZSZkZzZTBSeGJOR2JseDN2ZWdDeWdKci85bFJoMUVub0dKeWUwcHlrcAppQW5tSWltb0ZtNUxIa2xjSHFSbkJIZDFvZHZEUDJvTHJzdXg1ZHRjc2piYzFtK3F4QTRENm1DbzFKdldMelQvCjRzMHpuYlR4TDV5QWFYdFB1bk40S0ZJdU03ZFNjTXJ5SW9NTFhIK2NjUnpTdHRHYVJhWDlUVVZaWHBZam05RzQKcnExcGpSUDQ3NlU0dWxsZzNvMkFVMC9ia3N4R0tRclJRZ210dEczcVNuM0VNZjJPeXo4eUNOamFYQ2taV0ltbApDaUhoT2hycXRoaUs3SFJZWXVNQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFBRnMvQzF0ckp0VzNEamRJdzQvRkhmZ0Y3VW0KSEJlRmpiUmlGdjc5cFAvRFZhZUtiakdLQzR0U2hSUVhuTFp4N3ZyOE0xSXFrUUJGek1qRVlDLy9FbWtLSlYxagpuZDFuKy9WR0cwU2pNRnUvWGNBN2ZrL2llNVBlby9yaDBJOFZsckRxUklRTmZpelk5T3pJcFdDYS9sdGxwSnVlClB4UTNoWTVmbityUXlnTFZ5STNicWtqc2tZYzlyTmpuU1B4ZGdITVI4eUJESW1sb1RDYVYwUHVrWk0xV0pqMlAKN2lFZWU1cS9yeVp2V0s0OHJmMS95VG5NNDhaN1IwNy9PM3l0V00rU1VVQkFQNk1EdW5jNzlNajVuOUs0bExROApLeEIvdGZJS2FNbnFJRUxRYWUxekNEOWNIVXdWeDY2RmpldGtvZzlMVVp6MC9iYjYyYmhpY0xHQ09Iaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\",\"endpoint\":\"https://BE5C79AC824BB1EF67DB8CC14D6A263F.gr7.us-west-2.eks.amazonaws.com\",\"name\":\"etarn\"},\"labels\":{\"kubernetes.io/arch\":\"arm64\"}}}\n"}},"spec":{"labels":{"kubernetes.io/arch":"arm64"}}}
to:
Resource: "provisioning.karpenter.sh/v1alpha1, Resource=provisioners", GroupVersionKind: "provisioning.karpenter.sh/v1alpha1, Kind=Provisioner"
Name: "default", Namespace: "default"
for: "STDIN": admission webhook "vprovisioner.kb.io" denied the request: spec.labels contains restricted label kubernetes.io/arch
```

```
Error from server (unsupported architecture arm64aa): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"provisioning.karpenter.sh/v1alpha1\",\"kind\":\"Provisioner\",\"metadata\":{\"annotations\":{},\"name\":\"default\",\"namespace\":\"default\"},\"spec\":{\"architecture\":\"arm64aa\",\"cluster\":{\"caBundle\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ESXhNVEl3TURVeE0xb1hEVE14TURJd09USXdNRFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTEUxCjVlN0hoZXgvMHRZNlRmME1kam9HZ1lpRDFQb1pxUHphMUdkTDk0aVpmdm9xMC95d0QzeVhSeCtNbXY3aUJnRGwKQWw2cmRzNENJSXRKeFZ2eXZyQmFFWXZSZkZzZTBSeGJOR2JseDN2ZWdDeWdKci85bFJoMUVub0dKeWUwcHlrcAppQW5tSWltb0ZtNUxIa2xjSHFSbkJIZDFvZHZEUDJvTHJzdXg1ZHRjc2piYzFtK3F4QTRENm1DbzFKdldMelQvCjRzMHpuYlR4TDV5QWFYdFB1bk40S0ZJdU03ZFNjTXJ5SW9NTFhIK2NjUnpTdHRHYVJhWDlUVVZaWHBZam05RzQKcnExcGpSUDQ3NlU0dWxsZzNvMkFVMC9ia3N4R0tRclJRZ210dEczcVNuM0VNZjJPeXo4eUNOamFYQ2taV0ltbApDaUhoT2hycXRoaUs3SFJZWXVNQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFBRnMvQzF0ckp0VzNEamRJdzQvRkhmZ0Y3VW0KSEJlRmpiUmlGdjc5cFAvRFZhZUtiakdLQzR0U2hSUVhuTFp4N3ZyOE0xSXFrUUJGek1qRVlDLy9FbWtLSlYxagpuZDFuKy9WR0cwU2pNRnUvWGNBN2ZrL2llNVBlby9yaDBJOFZsckRxUklRTmZpelk5T3pJcFdDYS9sdGxwSnVlClB4UTNoWTVmbityUXlnTFZ5STNicWtqc2tZYzlyTmpuU1B4ZGdITVI4eUJESW1sb1RDYVYwUHVrWk0xV0pqMlAKN2lFZWU1cS9yeVp2V0s0OHJmMS95VG5NNDhaN1IwNy9PM3l0V00rU1VVQkFQNk1EdW5jNzlNajVuOUs0bExROApLeEIvdGZJS2FNbnFJRUxRYWUxekNEOWNIVXdWeDY2RmpldGtvZzlMVVp6MC9iYjYyYmhpY0xHQ09Iaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\",\"endpoint\":\"https://BE5C79AC824BB1EF67DB8CC14D6A263F.gr7.us-west-2.eks.amazonaws.com\",\"name\":\"etarn\"}}}\n"}},"spec":{"architecture":"arm64aa"}}
to:
Resource: "provisioning.karpenter.sh/v1alpha1, Resource=provisioners", GroupVersionKind: "provisioning.karpenter.sh/v1alpha1, Kind=Provisioner"
Name: "default", Namespace: "default"
for: "STDIN": admission webhook "vprovisioner.kb.io" denied the request: unsupported architecture arm64aa
```