### PR TITLE
add apache-2.0 license to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Issue #, if available:
+
+Description of changes:
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - The default pull request template doesn't specify the license. This change adds apache-2.0 license


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
