### PR TITLE
remove limits and add os and arch affinity

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -44,14 +44,24 @@ spec:
       labels:
         control-plane: karpenter
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
       serviceAccountName: karpenter
       containers:
       - name: manager
         image: ko://github.com/awslabs/karpenter/cmd/controller
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Add OS and Architecture affinity so that karpenter doesn't schedule to windows or arm64 nodes 
 - Remove cpu and memory limits to avoid OOM

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
