### PR TITLE
do not fail on create fleet launch errors

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -70,15 +70,15 @@ func (p *InstanceProvider) Create(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("creating fleet %w", err)
 	}
-	// TODO aggregate errors
-	if count := len(createFleetOutput.Errors); count > 0 {
-		return nil, fmt.Errorf("errors while creating fleet, %v", createFleetOutput.Errors)
-	}
 	if count := len(createFleetOutput.Instances); count != 1 {
-		return nil, fmt.Errorf("expected 1 instance, but got %d", count)
+		return nil, fmt.Errorf("expected 1 instance, but got %d due to errors %v", count, createFleetOutput.Errors)
 	}
 	if count := len(createFleetOutput.Instances[0].InstanceIds); count != 1 {
-		return nil, fmt.Errorf("expected 1 instance ids, but got %d", count)
+		return nil, fmt.Errorf("expected 1 instance ids, but got %d due to errors %v", count, createFleetOutput.Errors)
+	}
+	// TODO aggregate errors
+	if count := len(createFleetOutput.Errors); count > 0 {
+		zap.S().Warnf("CreateFleet encountered %d errors, but still launched instances, %v", count, createFleetOutput.Errors)
 	}
 	return createFleetOutput.Instances[0].InstanceIds[0], nil
 }


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Fleet returns back launch errors that may mean that the request was successful eventually. This can happen if one of the instance types results in an ICE, but fleet retries and is able to launch the capacity with another instance type specified in the request.  We see some errors now because some instance types are not available in all AZs. With this change, we only error out if the capacity is also not met. Otherwise, we print these errors as warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
