### PR TITLE
make easier to run commands if creating two stacks

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -16,7 +16,6 @@ eksctl create cluster \
 --name ${CLUSTER_NAME} \
 --version 1.19 \
 --region ${AWS_DEFAULT_REGION} \
---nodegroup-name karpenter-aws-demo \
 --node-type m5.large \
 --nodes 1 \
 --nodes-min 1 \


### PR DESCRIPTION
Issue #, if available:

Description of changes: I don't think refer to the name of the nodegroup anywhere, so it's easier if we just let `eksctl` create a random name for us.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
