### PR TITLE
Keep policy and profile also cluster specific

### DIFF
--- a/docs/aws/karpenter.cloudformation.yaml
+++ b/docs/aws/karpenter.cloudformation.yaml
@@ -33,7 +33,7 @@ Resources:
   KarpenterControllerPolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: Karpenter
+      PolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
       Roles:
         -
           Ref: "KarpenterControllerRole"
@@ -62,7 +62,7 @@ Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
-      InstanceProfileName: "KarpenterNodeInstanceProfile"
+      InstanceProfileName: !Sub "KarpenterNodeInstanceProfile-${ClusterName}"
       Path: "/"
       Roles:
         - Ref: "KarpenterNodeInstanceRole"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
If a karpenter specific cfn stack exists and these policy and profile are created, a second stack for the new cluster fails because these policy/profiles already exist in the account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
