### PR TITLE
Reverted eksctl create cluster version back to 1.18

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -14,7 +14,7 @@ Skip this step if you already have a cluster.
 ```bash
 eksctl create cluster \
 --name ${CLUSTER_NAME} \
---version 1.19 \
+--version 1.18 \
 --region ${AWS_DEFAULT_REGION} \
 --node-type m5.large \
 --nodes 1 \


### PR DESCRIPTION
1.19 currently breaks our subnet discovery system. https://github.com/weaveworks/eksctl/issues/3341

Change back to 1.19 when https://github.com/kubernetes/cloud-provider-aws/issues/184 gets resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
