### PR TITLE
Replaced context.TODO with actual contexts

### DIFF
--- a/pkg/cloudprovider/aws/capacity.go
+++ b/pkg/cloudprovider/aws/capacity.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"context"
 	"fmt"
-
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/packing"

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -20,13 +20,13 @@ import (
 	"math/rand"
 	"strings"
 
-	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/awslabs/karpenter/pkg/packing"
+
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
 )
 
 type InstanceProvider struct {
@@ -55,7 +55,6 @@ func (p *InstanceProvider) Create(ctx context.Context,
 			})
 		}
 	}
-
 	// 2. Create fleet
 	createFleetOutput, err := p.ec2api.CreateFleetWithContext(ctx, &ec2.CreateFleetInput{
 		Type: aws.String(ec2.FleetTypeInstant),

--- a/pkg/cloudprovider/aws/securitygroups.go
+++ b/pkg/cloudprovider/aws/securitygroups.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"context"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"

--- a/pkg/cloudprovider/aws/vpc.go
+++ b/pkg/cloudprovider/aws/vpc.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"context"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -46,7 +46,7 @@ func (c *GenericController) Reconcile(ctx context.Context, req reconcile.Request
 	// 2. Copy object for merge patch base
 	persisted := resource.DeepCopyObject()
 	// 3. Reconcile
-	if err := c.Controller.Reconcile(resource); err != nil {
+	if err := c.Controller.Reconcile(ctx, resource); err != nil {
 		resource.StatusConditions().MarkFalse(v1alpha1.Active, "", err.Error())
 		zap.S().Errorf("Controller failed to reconcile kind %s, %s",
 			resource.GetObjectKind().GroupVersionKind().Kind, err.Error())

--- a/pkg/controllers/provisioning/v1alpha1/allocation/bind.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/bind.go
@@ -17,7 +17,6 @@ package allocation
 import (
 	"context"
 	"fmt"
-
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
@@ -44,7 +43,6 @@ func (b *Binder) Bind(ctx context.Context, provisioner *v1alpha1.Provisioner, no
 		Type:   v1.NodeReady,
 		Status: v1.ConditionUnknown,
 	}}
-
 	// 2. Create node
 	if _, err := b.coreV1Client.Nodes().Create(ctx, node, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("creating node %s, %w", node.Name, err)

--- a/pkg/controllers/provisioning/v1alpha1/allocation/constraints.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/constraints.go
@@ -17,7 +17,6 @@ package allocation
 import (
 	"context"
 	"fmt"
-
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/utils/resources"

--- a/pkg/controllers/provisioning/v1alpha1/allocation/controller.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/controller.go
@@ -64,10 +64,8 @@ func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface
 }
 
 // Reconcile executes an allocation control loop for the resource
-func (c *Controller) Reconcile(object controllers.Object) error {
+func (c *Controller) Reconcile(ctx context.Context, object controllers.Object) error {
 	provisioner := object.(*v1alpha1.Provisioner)
-	ctx := context.TODO()
-
 	// 1. Filter pods
 	pods, err := c.filter.GetProvisionablePods(ctx, provisioner)
 	if err != nil {

--- a/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
@@ -17,7 +17,6 @@ package allocation
 import (
 	"context"
 	"fmt"
-
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/utils/functional"

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/controller.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/controller.go
@@ -62,9 +62,8 @@ func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface
 }
 
 // Reconcile executes a reallocation control loop for the resource
-func (c *Controller) Reconcile(object controllers.Object) error {
+func (c *Controller) Reconcile(ctx context.Context, object controllers.Object) error {
 	provisioner := object.(*v1alpha1.Provisioner)
-	ctx := context.TODO()
 	if err := c.utilization.Reconcile(ctx, provisioner); err != nil {
 		return fmt.Errorf("reconciling utilization sub-controller, %w", err)
 	}

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/suite_test.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/suite_test.go
@@ -70,6 +70,7 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("Reallocation", func() {
 	var provisioner *v1alpha1.Provisioner
+	var ctx context.Context
 
 	BeforeEach(func() {
 		provisioner = &v1alpha1.Provisioner{
@@ -80,6 +81,7 @@ var _ = Describe("Reallocation", func() {
 				Cluster: &v1alpha1.ClusterSpec{Name: "test-cluster", Endpoint: "http://test-cluster", CABundle: "dGVzdC1jbHVzdGVyCg=="},
 			},
 		}
+		ctx = context.Background()
 	})
 
 	AfterEach(func() {
@@ -101,7 +103,7 @@ var _ = Describe("Reallocation", func() {
 			ExpectEventuallyReconciled(env.Client, provisioner)
 
 			updatedNode := &v1.Node{}
-			Expect(env.Client.Get(context.Background(), client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
 			Expect(updatedNode.Labels).To(HaveKeyWithValue(v1alpha1.ProvisionerPhaseLabel, v1alpha1.ProvisionerUnderutilizedPhase))
 			Expect(updatedNode.Annotations).To(HaveKey(v1alpha1.ProvisionerTTLKey))
 		})
@@ -130,7 +132,7 @@ var _ = Describe("Reallocation", func() {
 			ExpectEventuallyReconciled(env.Client, provisioner)
 
 			updatedNode := &v1.Node{}
-			Expect(env.Client.Get(context.Background(), client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
 			Expect(updatedNode.Labels).ToNot(HaveKey(v1alpha1.ProvisionerPhaseLabel))
 			Expect(updatedNode.Annotations).ToNot(HaveKey(v1alpha1.ProvisionerTTLKey))
 		})
@@ -152,7 +154,7 @@ var _ = Describe("Reallocation", func() {
 			ExpectEventuallyReconciled(env.Client, provisioner)
 
 			updatedNode := &v1.Node{}
-			Eventually(Expect(errors.IsNotFound(env.Client.Get(context.Background(), client.ObjectKey{Name: node.Name}, updatedNode))).To(BeTrue()))
+			Eventually(Expect(errors.IsNotFound(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode))).To(BeTrue()))
 		})
 	})
 })

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/utilization.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/utilization.go
@@ -52,7 +52,6 @@ func (u *Utilization) Reconcile(ctx context.Context, provisioner *v1alpha1.Provi
 // markUnderutilized adds a TTL to underutilized nodes
 func (u *Utilization) markUnderutilized(ctx context.Context, provisioner *v1alpha1.Provisioner) error {
 	ttlable := []*v1.Node{}
-
 	// 1. Get all provisioner nodes
 	nodes, err := u.getNodes(ctx, provisioner, map[string]string{})
 	if err != nil {

--- a/pkg/controllers/types.go
+++ b/pkg/controllers/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"time"
 
 	"knative.dev/pkg/apis"
@@ -28,7 +29,7 @@ type Controller interface {
 	// Reconcile hands a hydrated kubernetes resource to the controller for
 	// reconciliation. Any changes made to the resource's status are persisted
 	// after Reconcile returns, even if it returns an error.
-	Reconcile(Object) error
+	Reconcile(context.Context, Object) error
 	// Interval returns an interval that the controller should wait before
 	// executing another reconciliation loop. If set to zero, will only execute
 	// on watch events or the global resync interval.


### PR DESCRIPTION
Looking for advice on what the default timeout for contexts should be. Ideally, any command we do shouldn't take anywhere close to 300 seconds. 

Replaced each context.TODO with proper contexts.
- Contexts will be created at the top level of each controller as a `context.Background()`
- Each time a context is used as a parameter, it only creates a new context if the command is a request (with timeout of 300 seconds)
  - Request to the API Server
  - Request to the AWS CLI 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
