### PR TITLE
short circuit if there are no schedulable pods in the allocation controller

### DIFF
--- a/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
@@ -40,6 +40,9 @@ func (f *Filter) GetProvisionablePods(ctx context.Context, provisioner *v1alpha1
 	if err := f.kubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": ""}); err != nil {
 		return nil, fmt.Errorf("listing unscheduled pods, %w", err)
 	}
+	if len(pods.Items) == 0 {
+		return nil, nil
+	}
 
 	// 2. Get Supported Labels
 	capacity := f.cloudProvider.CapacityFor(&provisioner.Spec)


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - A lot of cloud provider resources are being fetch unnecessarily if there are no pods to schedule and therefore check supported labels for. This change short circuits the fetching of cloud provider resources if there are no pods. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
