### PR TITLE
minimize logging and simplify instance types provider

### DIFF
--- a/pkg/cloudprovider/aws/capacity.go
+++ b/pkg/cloudprovider/aws/capacity.go
@@ -94,7 +94,7 @@ func (c *Capacity) Delete(ctx context.Context, nodes []*v1.Node) error {
 }
 
 func (c *Capacity) GetInstanceTypes(ctx context.Context) ([]string, error) {
-	return c.instanceTypeProvider.GetAllInstanceTypeNames(ctx, c.spec.Cluster.Name)
+	return c.instanceTypeProvider.GetAllInstanceTypeNames(ctx)
 }
 
 func (c *Capacity) GetZones(ctx context.Context) ([]string, error) {

--- a/pkg/cloudprovider/aws/factory.go
+++ b/pkg/cloudprovider/aws/factory.go
@@ -78,7 +78,7 @@ func NewFactory(options cloudprovider.Options) *Factory {
 		nodeFactory:            &NodeFactory{ec2api: ec2api},
 		packer:                 packing.NewPacker(),
 		instanceProvider:       &InstanceProvider{ec2api: ec2api, vpc: vpcProvider},
-		instanceTypeProvider:   NewInstanceTypeProvider(ec2api, vpcProvider),
+		instanceTypeProvider:   NewInstanceTypeProvider(ec2api),
 		launchTemplateProvider: launchTemplateProvider,
 	}
 }

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -63,12 +63,12 @@ func launchTemplateName(clusterName string, arch string) string {
 }
 
 func (p *LaunchTemplateProvider) Get(ctx context.Context, cluster *v1alpha1.ClusterSpec, constraints *cloudprovider.Constraints) (*ec2.LaunchTemplate, error) {
-	arch := utils.NormalizeArchitecture(*constraints.Architecture)
-	name := launchTemplateName(cluster.Name, arch)
+	arch := utils.NormalizeArchitecture(constraints.Architecture)
+	name := launchTemplateName(cluster.Name, *arch)
 	if launchTemplate, ok := p.cache.Get(name); ok {
 		return launchTemplate.(*ec2.LaunchTemplate), nil
 	}
-	launchTemplate, err := p.getLaunchTemplate(ctx, cluster, arch)
+	launchTemplate, err := p.getLaunchTemplate(ctx, cluster, *arch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -80,7 +80,7 @@ var env *test.Environment = test.NewEnvironment(func(e *test.Environment) {
 		vpcProvider:            vpcProvider,
 		nodeFactory:            &NodeFactory{ec2api: fakeEC2API},
 		instanceProvider:       &InstanceProvider{ec2api: fakeEC2API, vpc: vpcProvider},
-		instanceTypeProvider:   NewInstanceTypeProvider(fakeEC2API, vpcProvider),
+		instanceTypeProvider:   NewInstanceTypeProvider(fakeEC2API),
 		packer:                 packing.NewPacker(),
 		launchTemplateProvider: launchTemplateProvider,
 	}

--- a/pkg/cloudprovider/aws/utils/utils.go
+++ b/pkg/cloudprovider/aws/utils/utils.go
@@ -14,14 +14,20 @@ limitations under the License.
 
 package utils
 
-import "github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
+)
 
 // NormalizeArchitecture translates architecture into an AWS-recognized architecture name
-func NormalizeArchitecture(architecture string) string {
-	switch architecture {
+func NormalizeArchitecture(architecture *string) *string {
+	if architecture == nil {
+		return nil
+	}
+	switch *architecture {
 	case v1alpha1.ArchitectureAmd64:
-		return "x86_64"
+		return aws.String("x86_64")
 	default:
-		return string(architecture)
+		return architecture
 	}
 }

--- a/pkg/cloudprovider/aws/vpc.go
+++ b/pkg/cloudprovider/aws/vpc.go
@@ -109,7 +109,6 @@ func (p *VPCProvider) normalizeZones(ctx context.Context, zones []string) ([]str
 			}
 		}
 	}
-	zap.S().Debugf("Successfully normalized %d zone(s) to their respective zone name(s)", len(zones))
 	return zoneNames, nil
 }
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Restructured instance type provider to reduce ec2 InstanceTypeOffering API calls
   - `2021-03-31T00:17:09.790Z	DEBUG	Successfully discovered 392 EC2 instance types` is only logged one time per cache miss. 
 - Fixed bad log on normalizeZones, no need to log in that func at all.  
 - Retrieving all zones and caching as instance type with supported zones allowed a simplification of the provider (removing vpc provider dependency).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
