### PR TITLE
add zone-ids to zone validation

### DIFF
--- a/pkg/cloudprovider/aws/capacity.go
+++ b/pkg/cloudprovider/aws/capacity.go
@@ -17,6 +17,7 @@ package aws
 import (
 	"context"
 	"fmt"
+
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/packing"
@@ -97,7 +98,15 @@ func (c *Capacity) GetInstanceTypes(ctx context.Context) ([]string, error) {
 }
 
 func (c *Capacity) GetZones(ctx context.Context) ([]string, error) {
-	return c.vpcProvider.GetZones(ctx, c.spec.Cluster.Name)
+	azs, err := c.vpcProvider.GetAllAvailabilityZones(ctx)
+	if err != nil {
+		return nil, err
+	}
+	zones := []string{}
+	for _, az := range azs {
+		zones = append(zones, []string{*az.ZoneName, *az.ZoneId}...)
+	}
+	return zones, nil
 }
 
 func (c *Capacity) GetArchitectures(ctx context.Context) ([]string, error) {

--- a/pkg/cloudprovider/aws/capacity.go
+++ b/pkg/cloudprovider/aws/capacity.go
@@ -98,13 +98,13 @@ func (c *Capacity) GetInstanceTypes(ctx context.Context) ([]string, error) {
 }
 
 func (c *Capacity) GetZones(ctx context.Context) ([]string, error) {
-	azs, err := c.vpcProvider.GetAllAvailabilityZones(ctx)
+	azs, err := c.vpcProvider.GetAllZones(ctx)
 	if err != nil {
 		return nil, err
 	}
 	zones := []string{}
 	for _, az := range azs {
-		zones = append(zones, []string{*az.ZoneName, *az.ZoneId}...)
+		zones = append(zones, *az.ZoneName, *az.ZoneId)
 	}
 	return zones, nil
 }

--- a/pkg/cloudprovider/aws/vpc.go
+++ b/pkg/cloudprovider/aws/vpc.go
@@ -45,7 +45,7 @@ func NewVPCProvider(ec2api ec2iface.EC2API, subnetProvider *SubnetProvider) *VPC
 	}
 }
 
-func (p *VPCProvider) GetAllAvailabilityZones(ctx context.Context) ([]*ec2.AvailabilityZone, error) {
+func (p *VPCProvider) GetAllZones(ctx context.Context) ([]*ec2.AvailabilityZone, error) {
 	azs, ok := p.cache.Get(allZonesKey)
 	if ok {
 		return azs.([]*ec2.AvailabilityZone), nil
@@ -104,7 +104,7 @@ func (p *VPCProvider) GetZonalSubnets(ctx context.Context, constraints *cloudpro
 
 // normalizeZones takes zone names or ids and returns them all as zone names
 func (p *VPCProvider) normalizeZones(ctx context.Context, zones []string) ([]string, error) {
-	azs, err := p.GetAllAvailabilityZones(ctx)
+	azs, err := p.GetAllZones(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/karpenter/issues/261

Description of changes:
Support for zone-ids was actually implemented as part of the instance type provider PR (https://github.com/awslabs/karpenter/pull/307), but this PR adds zone-ids to the cloud provider GetZones list so the provisioner validation webhook will succeed if a user puts a zone-id in the provisioner.

---
provisioner.yml
```
apiVersion: provisioning.karpenter.sh/v1alpha1
kind: Provisioner
metadata:
spec:
  cluster:
....
    name: karpenter-test
  ttlSeconds: 10
  zones:
  - use1-az2
```

My account maps use1-az2 -> us-east-1a.  Tested launching several instance which all went to the proper AZ. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
