### PR TITLE
removed TODO per discussion

### DIFF
--- a/pkg/controllers/provisioning/v1alpha1/reallocation/terminate.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/terminate.go
@@ -130,8 +130,6 @@ func (t *Terminator) deleteNodes(ctx context.Context, nodes []*v1.Node, provisio
 		return fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
 	// 2. Delete node in APIServer
-	// TODO: Prevent leaked nodes: ensure a node is not deleted in apiserver if not deleted in cloudprovider
-	// Use the returned ids from the cloudprovider's Delete() function, and then only delete those ids in the apiserver
 	for _, node := range nodes {
 		if err := t.kubeClient.Delete(ctx, node); err != nil {
 			zap.S().Debugf("Continuing after failing to delete node %s, %s", node.Name, err.Error())


### PR DESCRIPTION
https://github.com/awslabs/karpenter/issues/275

Discussed [here](https://github.com/awslabs/karpenter/pull/335). The TODO was placed to ensure that if the Terminate API command succeeded but only terminated partial instances, that the node wouldn't be deleted in the APIServer. After realizing that the command would not error only if all instances are deleted, this TODO becomes unneeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
