### PR TITLE
add instance types to instance type tests

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Allocation", func() {
 			})
 			It("should succeed if supported", func() {
 				provisioner.Spec.InstanceTypes = []string{
-					// TODO @bwagner5
+					"m5.large",
 				}
 				Expect(env.Client.Create(context.Background(), provisioner)).To(Succeed())
 			})

--- a/pkg/webhooks/provisioning/v1alpha1/suite_test.go
+++ b/pkg/webhooks/provisioning/v1alpha1/suite_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Validation", func() {
 		})
 		It("should succeed if supported", func() {
 			provisioner.Spec.InstanceTypes = []string{
-				// TODO @bwagner5
+				"test-instance-type-1",
 			}
 			Expect(env.Client.Create(context.Background(), provisioner)).To(Succeed())
 		})


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Add instance types to InstanceType tests in cloudprovider aws and webhook validation tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
