### PR TITLE
update karpenter metrics clusterrole

### DIFF
--- a/charts/karpenter/templates/manifest.yaml
+++ b/charts/karpenter/templates/manifest.yaml
@@ -148,6 +148,7 @@ rules:
     resources:
       - services
       - endpoints
+      - pods
     verbs:
       - get
       - list


### PR DESCRIPTION
Without this, I get 
`prometheus level=error ts=2021-04-07T13:21:13.199Z caller=klog.go:96 component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.20.5/tools/cache/reflector.go:167: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:karpenter:default\" cannot list resource \"pods\" in API group \"\" in the namespace \"karpenter\""`
in the `prometheus-karpenter-monitor-0` logs

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
