### PR TITLE
add user-agent string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-GOFLAGS ?= "-tags=${CLOUD_PROVIDER}"
-
 RELEASE_REPO ?= public.ecr.aws/b6u6q9h4
-RELEASE_VERSION ?= v0.2.0
+RELEASE_VERSION ?= $(shell git describe --tags --always --dirty)
 RELEASE_MANIFEST = releases/${CLOUD_PROVIDER}/manifest.yaml
 
+## Inject the app version into project.Version
+LDFLAGS ?= "-ldflags=-X=github.com/awslabs/karpenter/pkg/utils/project.Version=${RELEASE_VERSION}"
+GOFLAGS ?= "-tags=${CLOUD_PROVIDER} ${LDFLAGS}"
 WITH_GOFLAGS = GOFLAGS=${GOFLAGS}
 WITH_RELEASE_REPO = KO_DOCKER_REPO=${RELEASE_REPO}
 

--- a/pkg/cloudprovider/aws/factory.go
+++ b/pkg/cloudprovider/aws/factory.go
@@ -53,8 +53,7 @@ type Factory struct {
 }
 
 func NewFactory(options cloudprovider.Options) *Factory {
-	sess := withRegion(session.Must(session.NewSession(&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint})))
-	sess = withUserAgent(sess)
+	sess := withUserAgent(withRegion(session.Must(session.NewSession(&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint}))))
 	ec2api := ec2.New(sess)
 	subnetProvider := &SubnetProvider{
 		ec2api: ec2api,

--- a/pkg/cloudprovider/aws/factory.go
+++ b/pkg/cloudprovider/aws/factory.go
@@ -13,11 +13,13 @@ limitations under the License.
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -26,6 +28,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/packing"
 	"github.com/awslabs/karpenter/pkg/utils/log"
+	"github.com/awslabs/karpenter/pkg/utils/project"
 	"github.com/patrickmn/go-cache"
 )
 
@@ -51,6 +54,8 @@ type Factory struct {
 
 func NewFactory(options cloudprovider.Options) *Factory {
 	sess := withRegion(session.Must(session.NewSession(&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint})))
+	// add karpenter user-agent string to AWS session
+	sess.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler(fmt.Sprintf("karpenter-%s", project.Version)))
 	ec2api := ec2.New(sess)
 	subnetProvider := &SubnetProvider{
 		ec2api: ec2api,

--- a/pkg/utils/project/project.go
+++ b/pkg/utils/project/project.go
@@ -19,6 +19,12 @@ import (
 	"runtime"
 )
 
+var (
+	// Version is the karpenter app version injected during compilation
+	// when using the Makefile
+	Version = "dev"
+)
+
 func RelativeToRoot(path string) string {
 	_, file, _, _ := runtime.Caller(0)
 	manifestsRoot := filepath.Join(filepath.Dir(file), "..", "..", "..")

--- a/pkg/utils/project/project.go
+++ b/pkg/utils/project/project.go
@@ -22,7 +22,7 @@ import (
 var (
 	// Version is the karpenter app version injected during compilation
 	// when using the Makefile
-	Version = "dev"
+	Version = "unspecified"
 )
 
 func RelativeToRoot(path string) string {


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Add a karpenter specific user-agent string w/ version to the AWS session 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
