### PR TITLE
remove retry library in favor of aws sdk retryer configured on the aws session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
-	gopkg.in/retry.v1 v1.0.3
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,6 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQW
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
-github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
-github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -406,7 +404,6 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -768,8 +765,6 @@ github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
-github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -1291,8 +1286,6 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXL
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
-gopkg.in/retry.v1 v1.0.3/go.mod h1:FJkXmWiMaAo7xB+xhvDF59zhfjDWyzmyAxiT4dB688g=
 gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/pkg/cloudprovider/aws/factory.go
+++ b/pkg/cloudprovider/aws/factory.go
@@ -57,7 +57,6 @@ func NewFactory(options cloudprovider.Options) *Factory {
 	sess := withUserAgent(withRegion(session.Must(
 		session.NewSession(request.WithRetryer(
 			&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint},
-			// use a custom retryer to take care of ec2 eventual consistency
 			utils.NewRetryer())))))
 	ec2api := ec2.New(sess)
 	subnetProvider := &SubnetProvider{

--- a/pkg/cloudprovider/aws/nodefactory.go
+++ b/pkg/cloudprovider/aws/nodefactory.go
@@ -39,7 +39,7 @@ func (n *NodeFactory) For(ctx context.Context, instanceIDs []*string) (map[strin
 	if aerr, ok := err.(awserr.Error); ok {
 		return nil, aerr
 	}
-	return nil, fmt.Errorf("failed to describe ec2 instances")
+	return nil, fmt.Errorf("failed to describe ec2 instances, %w", err)
 }
 
 func (n *NodeFactory) nodesFrom(reservations []*ec2.Reservation) map[string]*v1.Node {

--- a/pkg/cloudprovider/aws/nodefactory.go
+++ b/pkg/cloudprovider/aws/nodefactory.go
@@ -17,13 +17,10 @@ package aws
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"go.uber.org/zap"
-	"gopkg.in/retry.v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,22 +32,12 @@ type NodeFactory struct {
 
 // For a given set of instanceIDs return a map of instanceID to Kubernetes node object.
 func (n *NodeFactory) For(ctx context.Context, instanceIDs []*string) (map[string]*v1.Node, error) {
-	// Backoff retry is necessary here because EC2's APIs are eventually
-	// consistent. In most cases, this call will only be made once.
-	// TODO Use https://docs.aws.amazon.com/sdk-for-go/api/aws/request/#WithRetryer
-	for attempt := retry.Start(retry.Exponential{
-		Initial:  1 * time.Second,
-		MaxDelay: 10 * time.Second,
-		Factor:   2, Jitter: true,
-	}, nil); attempt.Next(); {
-		describeInstancesOutput, err := n.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
-		if err == nil {
-			return n.nodesFrom(describeInstancesOutput.Reservations), nil
-		}
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() != "InvalidInstanceID.NotFound" {
-			return nil, aerr
-		}
-		zap.S().Debugf("Retrying DescribeInstances due to eventual consistency: fleet created, but instances not yet found.")
+	describeInstancesOutput, err := n.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
+	if err == nil {
+		return n.nodesFrom(describeInstancesOutput.Reservations), nil
+	}
+	if aerr, ok := err.(awserr.Error); ok {
+		return nil, aerr
 	}
 	return nil, fmt.Errorf("failed to describe ec2 instances")
 }

--- a/pkg/cloudprovider/aws/utils/retryer.go
+++ b/pkg/cloudprovider/aws/utils/retryer.go
@@ -10,7 +10,7 @@ import (
 
 // Retryer implements the aws request.Retryer interface
 // and adds support for retrying ec2 InvalidInstanceID.NotFound
-// which can occurr when instances have recently been created
+// which can occur when instances have recently been created
 // and are not yet describe-able due to eventual consistency
 type Retryer struct {
 	baseRetryer request.Retryer

--- a/pkg/cloudprovider/aws/utils/retryer.go
+++ b/pkg/cloudprovider/aws/utils/retryer.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -13,40 +11,26 @@ import (
 // which can occur when instances have recently been created
 // and are not yet describe-able due to eventual consistency
 type Retryer struct {
-	baseRetryer request.Retryer
+	request.Retryer
 }
 
 // NewRetryer instantiates a Retryer based on aws client.DefaultRetryer w/ added functionality for karpenter
 func NewRetryer() *Retryer {
 	return &Retryer{
-		baseRetryer: client.DefaultRetryer{
+		Retryer: client.DefaultRetryer{
 			NumMaxRetries: 3,
 		},
 	}
 }
 
-// RetryRules returns the delay duration before retrying this request again
-func (r Retryer) RetryRules(req *request.Request) time.Duration {
-	return r.baseRetryer.RetryRules(req)
-}
-
 // ShouldRetry returns true if the request should be retried
 func (r Retryer) ShouldRetry(req *request.Request) bool {
-	if r.baseRetryer.ShouldRetry(req) {
+	if r.Retryer.ShouldRetry(req) {
 		return true
-	}
-	if req.Error == nil {
-		return false
 	}
 	// Retry DescribeInstances because EC2 is eventually consistent
 	if aerr, ok := req.Error.(awserr.Error); ok && aerr.Code() == "InvalidInstanceID.NotFound" {
 		return true
 	}
 	return false
-}
-
-// MaxRetries returns the number of maximum retries the service will use to make
-// an individual API request.
-func (r Retryer) MaxRetries() int {
-	return r.baseRetryer.MaxRetries()
 }

--- a/pkg/cloudprovider/aws/utils/retryer.go
+++ b/pkg/cloudprovider/aws/utils/retryer.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// Retryer implements the aws request.Retryer interface
+// and adds support for retrying ec2 InvalidInstanceID.NotFound
+// which can occurr when instances have recently been created
+// and are not yet describe-able due to eventual consistency
+type Retryer struct {
+	baseRetryer request.Retryer
+}
+
+// NewRetryer instantiates a Retryer based on aws client.DefaultRetryer w/ added functionality for karpenter
+func NewRetryer() *Retryer {
+	return &Retryer{
+		baseRetryer: client.DefaultRetryer{
+			NumMaxRetries: 3,
+		},
+	}
+}
+
+// RetryRules returns the delay duration before retrying this request again
+func (r Retryer) RetryRules(req *request.Request) time.Duration {
+	return r.baseRetryer.RetryRules(req)
+}
+
+// ShouldRetry returns true if the request should be retried
+func (r Retryer) ShouldRetry(req *request.Request) bool {
+	if r.baseRetryer.ShouldRetry(req) {
+		return true
+	}
+	if req.Error == nil {
+		return false
+	}
+	// Retry DescribeInstances because EC2 is eventually consistent
+	if aerr, ok := req.Error.(awserr.Error); ok && aerr.Code() == "InvalidInstanceID.NotFound" {
+		return true
+	}
+	return false
+}
+
+// MaxRetries returns the number of maximum retries the service will use to make
+// an individual API request.
+func (r Retryer) MaxRetries() int {
+	return r.baseRetryer.MaxRetries()
+}


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - remove retry library in favor of aws sdk retryer configured on the aws session

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
