### PR TITLE
Implemented support for Nvidia GPU and AWS Neuron

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider/registry"
 	"github.com/awslabs/karpenter/pkg/controllers"
 	"github.com/awslabs/karpenter/pkg/controllers/provisioning/v1alpha1/reallocation"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/awslabs/karpenter/pkg/controllers/provisioning/v1alpha1/allocation"
 	"github.com/awslabs/karpenter/pkg/utils/log"
@@ -45,8 +46,11 @@ func main() {
 	flag.IntVar(&options.WebhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to for validation and mutation of resources")
 	flag.IntVar(&options.MetricsPort, "metrics-port", 8080, "The port the metric endpoint binds to for operating metrics about the controller itself")
 	flag.Parse()
-
-	log.Setup(controllerruntimezap.UseDevMode(options.EnableVerboseLogging), controllerruntimezap.ConsoleEncoder())
+	log.Setup(
+		controllerruntimezap.UseDevMode(options.EnableVerboseLogging),
+		controllerruntimezap.ConsoleEncoder(),
+		controllerruntimezap.StacktraceLevel(zapcore.DPanicLevel),
+	)
 	manager := controllers.NewManagerOrDie(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
 		LeaderElection:     true,
 		LeaderElectionID:   "karpenter-leader-election",

--- a/pkg/cloudprovider/aws/capacity.go
+++ b/pkg/cloudprovider/aws/capacity.go
@@ -55,8 +55,8 @@ func (c *Capacity) Create(ctx context.Context, cloudProviderConstraints *cloudpr
 
 	// 4. Compute Packing given the pods and instance types
 	instancePackings := c.packer.Pack(ctx, constraints.Pods, zonalInstanceTypes, cloudProviderConstraints)
+	zap.S().Debugf("Computed %d packing(s) for %d provisionable pod(s)", len(instancePackings), len(constraints.Pods))
 
-	zap.S().Debugf("Computed packings for %d pod(s) onto %d node(s)", len(constraints.Pods), len(instancePackings))
 	launchTemplate, err := c.launchTemplateProvider.Get(ctx, c.spec.Cluster, constraints)
 	if err != nil {
 		return nil, fmt.Errorf("getting launch template, %w", err)

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -181,6 +181,57 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(ctx context.Context, inpu
 					Ipv4AddressesPerInterface: aws.Int64(60),
 				},
 			},
+			{
+				InstanceType:                  aws.String("p3.8xlarge"),
+				SupportedUsageClasses:         []*string{aws.String("on-demand")},
+				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
+				BurstablePerformanceSupported: aws.Bool(false),
+				BareMetal:                     aws.Bool(false),
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+				},
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(32),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(249856),
+				},
+				GpuInfo: &ec2.GpuInfo{
+					Gpus: []*ec2.GpuDeviceInfo{{
+						Manufacturer: aws.String("NVIDIA"),
+						Count:        aws.Int64(4),
+					}},
+				},
+				NetworkInfo: &ec2.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int64(4),
+					Ipv4AddressesPerInterface: aws.Int64(60),
+				},
+			},
+			{
+				InstanceType:                  aws.String("inf1.6xlarge"),
+				SupportedUsageClasses:         []*string{aws.String("on-demand")},
+				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
+				BurstablePerformanceSupported: aws.Bool(false),
+				BareMetal:                     aws.Bool(false),
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+				},
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(24),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(49152),
+				},
+				InferenceAcceleratorInfo: &ec2.InferenceAcceleratorInfo{
+					Accelerators: []*ec2.InferenceDeviceInfo{{
+						Manufacturer: aws.String("AWS"),
+						Count: aws.Int64(4),
+				}}},
+				NetworkInfo: &ec2.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int64(4),
+					Ipv4AddressesPerInterface: aws.Int64(60),
+				},
+			},
 		},
 	}, false)
 	return nil
@@ -222,6 +273,14 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(ctx context.Conte
 			},
 			{
 				InstanceType: aws.String("m5.8xlarge"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("p3.8xlarge"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("inf1.6xlarge"),
 				Location:     aws.String("test-zone-1a"),
 			},
 		},

--- a/pkg/cloudprovider/aws/nodefactory.go
+++ b/pkg/cloudprovider/aws/nodefactory.go
@@ -32,6 +32,10 @@ type NodeFactory struct {
 
 // For a given set of instanceIDs return a map of instanceID to Kubernetes node object.
 func (n *NodeFactory) For(ctx context.Context, instanceIDs []*string) (map[string]*v1.Node, error) {
+	// EC2 will return all instances if unspecified, so we must short circuit
+	if len(instanceIDs) == 0 {
+		return nil, nil
+	}
 	describeInstancesOutput, err := n.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
 	if err == nil {
 		return n.nodesFrom(describeInstancesOutput.Reservations), nil

--- a/pkg/cloudprovider/fake/capacity.go
+++ b/pkg/cloudprovider/fake/capacity.go
@@ -44,9 +44,9 @@ func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.Constr
 				Taints:     constraints.Taints,
 			},
 			Status: v1.NodeStatus{
-				// Right size the instance
+				// Right sized the instance
 				Allocatable: v1.ResourceList{
-					v1.ResourcePods:   resource.MustParse(fmt.Sprint(len(constraints.Pods) + 2)),
+					v1.ResourcePods:   resource.MustParse("1000000"),
 					v1.ResourceCPU:    *requests.Cpu(),
 					v1.ResourceMemory: *requests.Memory(),
 				},

--- a/pkg/cloudprovider/fake/capacity.go
+++ b/pkg/cloudprovider/fake/capacity.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
+	"github.com/awslabs/karpenter/pkg/utils/resources"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,7 @@ type Capacity struct {
 
 func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.Constraints) ([]cloudprovider.Packing, error) {
 	name := strings.ToLower(randomdata.SillyName())
+	requests := resources.Merge(resources.RequestsForPods(constraints.Pods...), constraints.Overhead)
 	return []cloudprovider.Packing{{
 		Node: &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -42,11 +44,11 @@ func (c *Capacity) Create(ctx context.Context, constraints *cloudprovider.Constr
 				Taints:     constraints.Taints,
 			},
 			Status: v1.NodeStatus{
+				// Right size the instance
 				Allocatable: v1.ResourceList{
-					// The (fake) mythical mega-machine
-					v1.ResourcePods:   resource.MustParse("1000000"),
-					v1.ResourceCPU:    resource.MustParse("1000000"),
-					v1.ResourceMemory: resource.MustParse("1000000Gi"),
+					v1.ResourcePods:   resource.MustParse(fmt.Sprint(len(constraints.Pods) + 2)),
+					v1.ResourceCPU:    *requests.Cpu(),
+					v1.ResourceMemory: *requests.Memory(),
 				},
 			},
 		},

--- a/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
+++ b/pkg/controllers/provisioning/v1alpha1/allocation/filter.go
@@ -147,7 +147,7 @@ func (f *Filter) hasSupportedLabels(pod *v1.Pod, supportedLabels map[string][]st
 			continue
 		}
 		if !functional.ContainsString(supported, selected) {
-			err = multierr.Append(err, fmt.Errorf("unsupported value for label %s = %s", label, selected))
+			err = multierr.Append(err, fmt.Errorf("unsupported value for label %s=%s", label, selected))
 		}
 	}
 	return err

--- a/pkg/packing/packing.go
+++ b/pkg/packing/packing.go
@@ -193,9 +193,9 @@ func weightOf(instance *Instance) float64 {
 func euclidean(values ...float64) float64 {
 	sum := float64(0)
 	for _, value := range values {
-		sum += math.Pow(2, value)
+		sum += math.Pow(value, 2)
 	}
-	return math.Pow(.5, sum)
+	return math.Pow(sum, .5)
 }
 
 func countNvidiaGPUs(instance *Instance) int64 {

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -14,9 +14,10 @@ import (
 type PodOptions struct {
 	Name             string
 	Namespace        string
+	OwnerReferences  []metav1.OwnerReference
 	Image            string
 	NodeName         string
-	ResourceRequests v1.ResourceList
+	ResourceRequirements v1.ResourceRequirements
 	NodeSelector     map[string]string
 	Tolerations      []v1.Toleration
 	Conditions       []v1.PodCondition
@@ -37,8 +38,9 @@ func defaults(options PodOptions) *v1.Pod {
 	}
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      options.Name,
-			Namespace: options.Namespace,
+			Name:            options.Name,
+			Namespace:       options.Namespace,
+			OwnerReferences: options.OwnerReferences,
 		},
 		Spec: v1.PodSpec{
 			NodeSelector: options.NodeSelector,
@@ -46,9 +48,7 @@ func defaults(options PodOptions) *v1.Pod {
 			Containers: []v1.Container{{
 				Name:  options.Name,
 				Image: options.Image,
-				Resources: v1.ResourceRequirements{
-					Requests: options.ResourceRequests,
-				},
+				Resources: options.ResourceRequirements,
 			}},
 			NodeName: options.NodeName,
 		},

--- a/pkg/utils/binpacking/binpacking.go
+++ b/pkg/utils/binpacking/binpacking.go
@@ -33,8 +33,8 @@ func (pods SortablePods) Swap(i, j int) {
 type ByResourcesRequested struct{ SortablePods }
 
 func (r ByResourcesRequested) Less(a, b int) bool {
-	resourcePodA := resources.ForPods(&r.SortablePods[a].Spec)
-	resourcePodB := resources.ForPods(&r.SortablePods[b].Spec)
+	resourcePodA := resources.RequestsForPods(r.SortablePods[a])
+	resourcePodB := resources.RequestsForPods(r.SortablePods[b])
 	if resourcePodA.Cpu().Equal(*resourcePodB.Cpu()) {
 		// check for memory
 		return resourcePodA.Memory().Cmp(*resourcePodB.Memory()) == -1


### PR DESCRIPTION
```
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:30.919Z	DEBUG	Successfully discovered 392 EC2 instance types
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:30.919Z	INFO	Found 1 provisionable pods
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:31.208Z	DEBUG	Successfully discovered subnets in 3 zones for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:31.210Z	DEBUG	Selected 20 instance type options for 1 pod(s) [g3.16xlarge g3.4xlarge p3.2xlarge g3.8xlarge g2.2xlarge g4dn.12xlarge p4d.24xlarge p2.8xlarge g4dn.xlarge g3s.xlarge p2.16xlarge p3.8xlarge g4dn.2xlarge p3.16xlarge g4dn.4xlarge g4dn.16xlarge g2.8xlarge p2.xlarge g4dn.8xlarge p3dn.24xlarge]
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:31.210Z	DEBUG	Computed packings for 1 pod(s) onto 1 node(s)
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:31.252Z	DEBUG	Successfully discovered launch template Karpenter-etarn-x86_64 for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:32.979Z	INFO	Binding 1 pods to node ip-192-168-186-217.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:03:32.995Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-8s9dm to node ip-192-168-186-217.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:04.868Z	DEBUG	Successfully discovered 392 EC2 instance types
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:04.869Z	INFO	Found 6 provisionable pods
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:05.050Z	DEBUG	Successfully discovered subnets in 3 zones for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:05.052Z	DEBUG	Selected 5 instance type options for 6 pod(s) [p2.8xlarge p4d.24xlarge p2.16xlarge p3.16xlarge p3dn.24xlarge]
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:05.052Z	DEBUG	Computed packings for 6 pod(s) onto 1 node(s)
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:05.106Z	DEBUG	Successfully discovered launch template Karpenter-etarn-x86_64 for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:06.790Z	DEBUG	Retrying DescribeInstances due to eventual consistency: fleet created, but instances not yet found.
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.808Z	INFO	Binding 6 pods to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.825Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-dxw8w to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.838Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-f76d6 to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.850Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-w7k48 to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.867Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-d6tpq to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.876Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-lx6lh to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:12:07.886Z	DEBUG	Successfully bound pod default/inflate-6c85695c99-55gg8 to node ip-192-168-126-156.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:03.331Z	INFO	Found 3 provisionable pods
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:03.332Z	DEBUG	Selected 2 instance type options for 3 pod(s) [inf1.6xlarge inf1.24xlarge]
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:03.332Z	DEBUG	Computed packings for 3 pod(s) onto 1 node(s)
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:05.558Z	INFO	Binding 3 pods to node ip-192-168-22-163.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:05.572Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-j47tx to node ip-192-168-22-163.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:05.581Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-pwbh5 to node ip-192-168-22-163.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:16:05.590Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-j4nx4 to node ip-192-168-22-163.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.578Z	DEBUG	Successfully discovered 392 EC2 instance types
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.579Z	INFO	Found 3 provisionable pods
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.787Z	DEBUG	Successfully discovered subnets in 3 zones for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.789Z	DEBUG	Selected 2 instance type options for 3 pod(s) [inf1.6xlarge inf1.24xlarge]
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.789Z	DEBUG	Computed packings for 3 pod(s) onto 1 node(s)
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:16.832Z	DEBUG	Successfully discovered launch template Karpenter-etarn-x86_64 for cluster etarn
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:18.359Z	INFO	Binding 3 pods to node ip-192-168-72-246.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:18.373Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-98cgz to node ip-192-168-72-246.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:18.381Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-7mwfs to node ip-192-168-72-246.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:17:18.394Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-sbk8t to node ip-192-168-72-246.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:03.472Z	INFO	Found 1 provisionable pods
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:03.474Z	DEBUG	Selected 4 instance type options for 1 pod(s) [inf1.xlarge inf1.2xlarge inf1.6xlarge inf1.24xlarge]
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:03.474Z	DEBUG	Computed packings for 1 pod(s) onto 1 node(s)
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:05.071Z	DEBUG	Retrying DescribeInstances due to eventual consistency: fleet created, but instances not yet found.
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:06.031Z	INFO	Binding 1 pods to node ip-192-168-119-157.us-west-2.compute.internal
karpenter-7fc58bdcf9-sjvtp manager 2021-04-14T23:18:06.045Z	DEBUG	Successfully bound pod default/inflate-5bb6755d98-snw2j to node ip-192-168-119-157.us-west-2.compute.internal
```