### PR TITLE
Properly implemented exponential backoff for reconciliation failures

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -9,13 +9,13 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider/registry"
 	"github.com/awslabs/karpenter/pkg/controllers"
 	"github.com/awslabs/karpenter/pkg/controllers/provisioning/v1alpha1/reallocation"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/awslabs/karpenter/pkg/controllers/provisioning/v1alpha1/allocation"
 	"github.com/awslabs/karpenter/pkg/utils/log"
 	webhooksprovisioning "github.com/awslabs/karpenter/pkg/webhooks/provisioning/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -46,6 +46,7 @@ func main() {
 	flag.IntVar(&options.WebhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to for validation and mutation of resources")
 	flag.IntVar(&options.MetricsPort, "metrics-port", 8080, "The port the metric endpoint binds to for operating metrics about the controller itself")
 	flag.Parse()
+
 	log.Setup(
 		controllerruntimezap.UseDevMode(options.EnableVerboseLogging),
 		controllerruntimezap.ConsoleEncoder(),

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -50,10 +50,11 @@ func (c *GenericController) Reconcile(ctx context.Context, req reconcile.Request
 		resource.StatusConditions().MarkFalse(v1alpha1.Active, "", err.Error())
 		zap.S().Errorf("Controller failed to reconcile kind %s, %s",
 			resource.GetObjectKind().GroupVersionKind().Kind, err.Error())
+		return reconcile.Result{Requeue: true}, nil
 	} else {
 		resource.StatusConditions().MarkTrue(v1alpha1.Active)
 	}
-	// 5. Update Status using a merge patch
+	// 4. Update Status using a merge patch
 	if err := c.Status().Patch(ctx, resource, client.MergeFrom(persisted)); err != nil {
 		return reconcile.Result{}, fmt.Errorf("Failed to persist changes to %s, %w", req.NamespacedName, err)
 	}

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -16,15 +16,20 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/awslabs/karpenter/pkg/apis"
 	"github.com/awslabs/karpenter/pkg/utils/log"
+
+	"golang.org/x/time/rate"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -54,16 +59,22 @@ func NewManagerOrDie(config *rest.Config, options controllerruntime.Options) Man
 
 // RegisterControllers registers a set of controllers to the controller manager
 func (m *GenericControllerManager) RegisterControllers(controllers ...Controller) Manager {
-	for _, controller := range controllers {
-		controlledObject := controller.For()
-		var builder = controllerruntime.NewControllerManagedBy(m).For(controlledObject)
-		if namedController, ok := controller.(NamedController); ok {
+	for _, c := range controllers {
+		controlledObject := c.For()
+		builder := controllerruntime.NewControllerManagedBy(m).For(controlledObject).WithOptions(controller.Options{
+			RateLimiter: workqueue.NewMaxOfRateLimiter(
+				workqueue.NewItemExponentialFailureRateLimiter(100*time.Millisecond, 10*time.Second),
+				// 10 qps, 100 bucket size
+				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			),
+		})
+		if namedController, ok := c.(NamedController); ok {
 			builder.Named(namedController.Name())
 		}
-		for _, resource := range controller.Owns() {
+		for _, resource := range c.Owns() {
 			builder = builder.Owns(resource)
 		}
-		log.PanicIfError(builder.Complete(&GenericController{Controller: controller, Client: m.GetClient()}),
+		log.PanicIfError(builder.Complete(&GenericController{Controller: c, Client: m.GetClient()}),
 			"Failed to register controller to manager for %s", controlledObject)
 		log.PanicIfError(controllerruntime.NewWebhookManagedBy(m).For(controlledObject).Complete(),
 			"Failed to register controller to manager for %s", controlledObject)


### PR DESCRIPTION
https://github.com/awslabs/karpenter/issues/358

If it fails, it exponentially backs off from `100ms` to `10s` detailed below.

```100ms -> 200ms -> 400ms -> 800 ms -> 1.6s -> 3.2s -> 6.4s -> 10s -> 10s -> 10s ....```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
