### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![Build Status](https://img.shields.io/github/workflow/status/awslabs/karpenter/CI)
+![Build Status](https://img.shields.io/github/workflow/status/awslabs/karpenter/CI/main)
 ![Go Report](https://goreportcard.com/badge/github.com/awslabs/karpenter)
 ![GitHub stars](https://img.shields.io/github/stars/awslabs/karpenter)
 ![GitHub forks](https://img.shields.io/github/forks/awslabs/karpenter)
-![GitHub License](https://img.shields.io/github/license/awslabs/karpenter)
+[![GitHub License](https://img.shields.io/badge/License-Apache%202.0-ff69b4.svg)](https://github.com/awslabs/karpenter/blob/main/LICENSE)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/awslabs/karpenter/issues)
 
 ![](docs/images/karpenter-banner.png)


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Github got confused on license when another file was added with the word license. Explicitly specified Apache 2.0 
 - Show build status for main branch rather than the latest build since that picks up PR builds too

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
