### PR TITLE
remove monitoring ns deletion

### DIFF
--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -31,7 +31,7 @@ EOF
 delete() {
   helm delete karpenter || true
   helm delete cert-manager --namespace cert-manager || true
-  kubectl delete namespace karpenter cert-manager monitoring || true
+  kubectl delete namespace karpenter cert-manager || true
 }
 
 # If this fails you may have an old installation hanging around.


### PR DESCRIPTION
Issue #, if available:

Description of changes:
We removed Prometheus, so no pods remain in the `monitoring` namespace. We don't want to delete namespaces that we do not own. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
