### PR TITLE
[Bug Fix] Added Missing IAM Permission

### DIFF
--- a/docs/aws/karpenter.cloudformation.yaml
+++ b/docs/aws/karpenter.cloudformation.yaml
@@ -58,6 +58,7 @@ Resources:
               - "ec2:DescribeInstanceTypes"
               - "ec2:DescribeInstanceTypeOfferings"
               - "ec2:DescribeAvailabilityZones"
+              - "iam:GetInstanceProfile"
               - "ssm:GetParameter"
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"


### PR DESCRIPTION
**Description of changes:**
When working through the getting started docs I noticed an IAM permission was missing in the sample IAM cloudformation.

```
2021-05-18T09:08:12.349Z        ERROR   Continuing after failing to create capacity, getting launch template, getting instance profile, retrieving instance profile KarpenterNodeInstanceProfile-olly-karpenter-demo, AccessDenied: User: arn:aws:sts::<accountid>:assumed-role/KarpenterControllerRole-olly-karpenter-demo/1621328854438905270 is not authorized to perform: iam:GetInstanceProfile on resource: instance profile KarpenterNodeInstanceProfile-olly-karpenter-demo
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
