### PR TITLE
Explicitly set output of aws cli to json

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -30,7 +30,7 @@ aws cloudformation deploy \
   --stack-name Karpenter-${CLUSTER_NAME} \
   --template-file ./docs/aws/karpenter.cloudformation.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
-  --parameter-overrides ClusterName=${CLUSTER_NAME} OpenIDConnectIdentityProvider=$(aws eks describe-cluster --name ${CLUSTER_NAME} | jq -r ".cluster.identity.oidc.issuer" | cut -c9-)
+  --parameter-overrides ClusterName=${CLUSTER_NAME} OpenIDConnectIdentityProvider=$(aws eks describe-cluster --name ${CLUSTER_NAME} --output json | jq -r ".cluster.identity.oidc.issuer" | cut -c9-)
 ```
 
 ### Install Karpenter Controller and Dependencies
@@ -89,8 +89,8 @@ metadata:
 spec:
   cluster:
     name: ${CLUSTER_NAME}
-    caBundle: $(aws eks describe-cluster --name ${CLUSTER_NAME} | jq ".cluster.certificateAuthority.data")
-    endpoint: $(aws eks describe-cluster --name ${CLUSTER_NAME} | jq ".cluster.endpoint")
+    caBundle: $(aws eks describe-cluster --name ${CLUSTER_NAME} --output json | jq ".cluster.certificateAuthority.data")
+    endpoint: $(aws eks describe-cluster --name ${CLUSTER_NAME} --output json | jq ".cluster.endpoint")
 EOF
 kubectl get provisioner default -oyaml
 ```


### PR DESCRIPTION
**Description of changes:**
 When working through the getting started docs I noticed an issue with `aws` commands that were piped to `jq`, and cause an error like:

```
parse error: Invalid numeric literal at line 1, column 8
```

This was because my default output was not set to `json` for the AWS CLI, so added the `--output json` option to the relevant commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
