### PR TITLE
Allow Karpenter controller to run on Fargate

### DIFF
--- a/charts/karpenter/templates/controller.yaml
+++ b/charts/karpenter/templates/controller.yaml
@@ -79,6 +79,10 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+          env:
+          {{- with .Values.controller.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074
       securityContext:
         fsGroup: 1000

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -4,6 +4,10 @@ serviceAccount:
   # Annotations to add to the service account (like the ARN of the IRSA role)
   annotations: {}
 controller:
+  # List of environment items to add to the controller, for example
+  # - name: AWS_REGION
+  #   value: eu-west-1
+  env: []
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Karpenter currently relies on EC2 instance metadata service (IMDS) to figure out which AWS region it is running in. IMDS is not available for pods running on EKS Fargate ([ref](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html)). This change preserves region discovery via EC2 IMDS if the Go SDK has not picked up region configuration via the environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
