### PR TITLE
helm chart: namespace related fixes

### DIFF
--- a/charts/karpenter/templates/cert-manager.yaml
+++ b/charts/karpenter/templates/cert-manager.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: karpenter-selfsigned-issuer
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -10,11 +10,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: karpenter-serving-cert
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - karpenter-webhook-service.karpenter.svc
-  - karpenter-webhook-service.karpenter.svc.cluster.local
+  - karpenter-webhook-service.{{ .Release.Namespace }}.svc
+  - karpenter-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: karpenter-selfsigned-issuer

--- a/charts/karpenter/templates/controller.yaml
+++ b/charts/karpenter/templates/controller.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: karpenter-webhook-service
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: karpenter
 spec:
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: karpenter-metrics-service
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: karpenter
 spec:
@@ -39,7 +39,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: karpenter
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: karpenter
 spec:

--- a/charts/karpenter/templates/manifests.yaml
+++ b/charts/karpenter/templates/manifests.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: karpenter-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: karpenter/karpenter-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/karpenter-serving-cert
 webhooks:
   - admissionReviewVersions:
       - v1beta1
@@ -12,7 +12,7 @@ webhooks:
       caBundle: Cg==
       service:
         name: karpenter-webhook-service
-        namespace: karpenter
+        namespace: {{ .Release.Namespace }}
         path: /mutate-provisioning-karpenter-sh-v1alpha1-provisioner
     failurePolicy: Fail
     name: mutation.provisioning.karpenter.sh
@@ -34,7 +34,7 @@ metadata:
   creationTimestamp: null
   name: karpenter-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: karpenter/karpenter-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/karpenter-serving-cert
 webhooks:
   - admissionReviewVersions:
       - v1beta1
@@ -42,7 +42,7 @@ webhooks:
       caBundle: Cg==
       service:
         name: karpenter-webhook-service
-        namespace: karpenter
+        namespace: {{ .Release.Namespace }}
         path: /validate-provisioning-karpenter-sh-v1alpha1-provisioner
     failurePolicy: Fail
     name: validation.provisioning.karpenter.sh

--- a/charts/karpenter/templates/rbac.yaml
+++ b/charts/karpenter/templates/rbac.yaml
@@ -1,12 +1,14 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: karpenter
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -19,12 +21,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: karpenter
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: karpenter-leader-election
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -32,12 +35,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: karpenter
-  namespace: karpenter
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: karpenter-leader-election
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -1,4 +1,5 @@
 serviceAccount:
+  create: true
   # Annotations to add to the service account (like the ARN of the IRSA role)
   annotations: {}
 controller:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* namespaces was hard-coded into the templates, this is now templated via helm
* exposes the creation of service account in the helm chart, so that creation can be prevented if the SA already exist (for example, if created via other IaC tooling)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
