### PR TITLE
Factored in overhead properly to avoid OutOfCPU or OutOfMemory errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,16 @@ licenses: ## Verifies dependency licenses and requires GITHUB_TOKEN to be set
 
 apply: ## Deploy the controller into your ~/.kube/config cluster
 	helm template karpenter charts/karpenter \
-	  $(HELM_OPTS) \
-		--set controller.image=ko://github.com/awslabs/karpenter/cmd/controller | \
-		$(WITH_GOFLAGS) ko apply -B -f -
+		$(HELM_OPTS) \
+		--create-namespace --namespace karpenter \
+		--set controller.image=ko://github.com/awslabs/karpenter/cmd/controller \
+		| $(WITH_GOFLAGS) ko apply -B -f -
 
 delete: ## Delete the controller from your ~/.kube/config cluster
-	helm template karpenter $(HELM_OPTS) charts/karpenter | ko delete -f -
+	helm template karpenter charts/karpenter \
+		$(HELM_OPTS) \
+		--create-namespace --namespace karpenter \
+		| $(WITH_GOFLAGS) ko delete -f -
 
 codegen: ## Generate code. Must be run if changes are made to ./pkg/apis/...
 	./hack/codegen.sh

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -159,7 +159,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(ctx context.Context, inpu
 					DefaultVCpus: aws.Int64(2),
 				},
 				MemoryInfo: &ec2.MemoryInfo{
-					SizeInMiB: aws.Int64(8),
+					SizeInMiB: aws.Int64(8 * 1024),
 				},
 				NetworkInfo: &ec2.NetworkInfo{
 					MaximumNetworkInterfaces:  aws.Int64(3),
@@ -179,7 +179,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(ctx context.Context, inpu
 					DefaultVCpus: aws.Int64(4),
 				},
 				MemoryInfo: &ec2.MemoryInfo{
-					SizeInMiB: aws.Int64(16),
+					SizeInMiB: aws.Int64(16 * 1024),
 				},
 				NetworkInfo: &ec2.NetworkInfo{
 					MaximumNetworkInterfaces:  aws.Int64(4),

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -24,6 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// EC2VMOverheadFactor assumes the EC2 VM will consume <7.25% of the memory of a given machine
+const EC2VMAvailableMemoryFactor = .925
+
 type InstanceType struct {
 	ec2.InstanceTypeInfo
 	ZoneOptions []string
@@ -53,7 +56,11 @@ func (i *InstanceType) CPU() *resource.Quantity {
 }
 
 func (i *InstanceType) Memory() *resource.Quantity {
-	return resources.Quantity(fmt.Sprintf("%dMi", *i.MemoryInfo.SizeInMiB))
+	return resources.Quantity(
+		fmt.Sprintf("%dMi", int32(
+			float64(*i.MemoryInfo.SizeInMiB)*EC2VMAvailableMemoryFactor,
+		)),
+	)
 }
 
 func (i *InstanceType) Pods() *resource.Quantity {
@@ -97,13 +104,24 @@ func (i *InstanceType) AWSNeurons() *resource.Quantity {
 	return resources.Quantity(fmt.Sprint(count))
 }
 
-// Overhead calculations copied from
-// https://github.com/awslabs/amazon-eks-ami/blob/5a3df0fdb17e540f8d5a9b405096f32d6b9b0a3f/files/bootstrap.sh#L237
+// Computes overhead for https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable
+// Overhead calculations copied from https://github.com/bottlerocket-os/bottlerocket#kubernetes-settings
 func (i *InstanceType) Overhead() v1.ResourceList {
 	overhead := v1.ResourceList{
-		v1.ResourceCPU:    *resource.NewMilliQuantity(int64(0), resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewMilliQuantity((11*i.Pods().Value())+255, resource.DecimalSI),
+		v1.ResourceCPU: *resource.NewMilliQuantity(
+			100, // system-reserved
+			resource.DecimalSI),
+		v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi",
+			// kube-reserved
+			((11*i.Pods().Value())+255)+
+				// system-reserved
+				100+
+				// eviction threshhold https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L23
+				100,
+		)),
 	}
+	// kube-reserved Computed from
+	// https://github.com/bottlerocket-os/bottlerocket/pull/1388/files#diff-bba9e4e3e46203be2b12f22e0d654ebd270f0b478dd34f40c31d7aa695620f2fR611
 	for _, cpuRange := range []struct {
 		start      int64
 		end        int64

--- a/pkg/packing/packable.go
+++ b/pkg/packing/packable.go
@@ -56,7 +56,7 @@ func PackablesFor(instanceTypes []cloudprovider.InstanceType, constraints *Const
 		}
 		// 2. Calculate Kubelet Overhead
 		if ok := packable.reserve(instanceType.Overhead()); !ok {
-			zap.S().Debugf("Excluding instance type %s because there are not enough resources for the kubelet overhead", packable.Name())
+			zap.S().Debugf("Excluding instance type %s because there are not enough resources for kubelet and system overhead", packable.Name())
 			continue
 		}
 		// 3. Calculate Daemonset Overhead


### PR DESCRIPTION
Issue #, if available: #393

Description of changes:

Implementation driven by https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources

Modeling a few ec2 instances here: https://docs.google.com/spreadsheets/d/1-mCo9-P2ThQxV0VdLbvyM59glykheP3pCBAZRdquZng/edit#gid=0

Note: I can't account for the difference between Kubernete's discovered Capacity and EC2's advertised memory values. To address this, we need to include an additional buffer. I chose 7.25%, since overhead is a monotonically decreasing function, with c5a.micro as largest percentage overhead of 7.04%. Nanos are excluded, since pods will never fit on them given default overhead values.
```
karpenter-5799c57d45-ts889 manager 2021-05-21T20:12:29.675Z	DEBUG	Excluding instance type t3.nano because there are not enough resources for kubelet and system overhead
karpenter-5799c57d45-ts889 manager 2021-05-21T20:12:29.679Z	DEBUG	Excluding instance type t3a.nano because there are not enough resources for kubelet and system overhead
```
## Instance types
### T3A.Nano
```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      463452Ki
  pods:                        4
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1930m
  ephemeral-storage:           17933882132
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      54876Ki
  pods:                        4
```

### T3A.Micro
```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      974684Ki
  pods:                        4
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1930m
  ephemeral-storage:           17933882132
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      566108Ki
  pods:                        4
```

### T3A.Small
```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      1997148Ki
  pods:                        8
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1930m
  ephemeral-storage:           17933882132
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      1543516Ki
  pods:                        8
```

### C5A.24xlarge
```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         96
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      195785704Ki
  pods:                        737
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         95690m
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      187120616Ki
  pods:                        737
```





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
