### PR TITLE
Properly delete Karpenter release on uninstall and wait for Cert-Manager on install

### DIFF
--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -29,7 +29,7 @@ EOF
 }
 
 delete() {
-  helm delete karpenter || true
+  helm delete karpenter --namespace karpenter || true
   helm delete cert-manager --namespace cert-manager || true
   kubectl delete namespace karpenter cert-manager || true
 }
@@ -47,10 +47,12 @@ apply() {
     --create-namespace --namespace cert-manager \
     --set installCRDs=true \
     --atomic
+  # https://cert-manager.io/docs/concepts/webhook/#webhook-connection-problems-shortly-after-cert-manager-installation
+  echo "Waiting for cert-manager to become usable"
+  sleep 10
   helm upgrade --install karpenter karpenter/karpenter \
     --create-namespace --namespace karpenter \
     --atomic
 }
 
-usage
 main "$@"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- added `--namespace karpenter` to delete command to delete the release in the proper namespace
- Cert-manager takes a little bit to become usable. This is well known and documented [here](https://cert-manager.io/docs/concepts/webhook/#webhook-connection-problems-shortly-after-cert-manager-installation). Immediately attempting to install Karpenter after Cert-manager results in a failure below. 
```
Error: release karpenter failed, and has been uninstalled due to atomic being set: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s: x509: certificate signed by unknown authority
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
