### PR TITLE
remove go-report-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Build Status](https://img.shields.io/github/workflow/status/awslabs/karpenter/CI/main)
-[![Go Report Card](https://goreportcard.com/badge/github.com/awslabs/karpenter)](https://goreportcard.com/report/github.com/awslabs/karpenter)
 ![GitHub stars](https://img.shields.io/github/stars/awslabs/karpenter)
 ![GitHub forks](https://img.shields.io/github/forks/awslabs/karpenter)
 [![GitHub License](https://img.shields.io/badge/License-Apache%202.0-ff69b4.svg)](https://github.com/awslabs/karpenter/blob/main/LICENSE)


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Remove go-report-card because it seems to be unstable and giving us an F :(  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
