### PR TITLE
Support for Subnets specification/override

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -73,7 +73,7 @@ func main() {
 			ServiceName: "karpenter-webhook",
 			SecretName:  "karpenter-webhook-cert",
 		}),
-		"Karpenter Webhooks",
+		"karpenter.webhooks",
 		config,
 		certificates.NewController,
 		NewCRDDefaultingWebhook,

--- a/pkg/apis/provisioning/v1alpha1/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner.go
@@ -138,7 +138,7 @@ type ProvisionerList struct {
 }
 
 func (c *Constraints) WithLabel(key string, value string) *Constraints {
-	c.Labels[key] = value
+	c.Labels = functional.UnionStringMaps(c.Labels, map[string]string{key: value})
 	return c
 }
 

--- a/pkg/apis/provisioning/v1alpha1/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner.go
@@ -138,7 +138,7 @@ type ProvisionerList struct {
 }
 
 func (c *Constraints) WithLabel(key string, value string) *Constraints {
-	c.Labels = functional.UnionStringMaps(c.Labels, map[string]string{key: value})
+	c.Labels[key] = value
 	return c
 }
 

--- a/pkg/apis/provisioning/v1alpha1/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner_validation.go
@@ -53,18 +53,18 @@ func (p *Provisioner) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 func (s *ProvisionerSpec) validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs.Also(
-		s.Cluster.validate(ctx).ViaField("cluster"),
-		// This validation is on the ProvisionerSpec despire the fact that
+		s.Cluster.validate().ViaField("cluster"),
+		// This validation is on the ProvisionerSpec despite the fact that
 		// labels are a property of Constraints. This is necessary because
 		// validation is applied to constraints that include pod overrides.
 		// These labels are restricted when creating provisioners, but are not
 		// restricted for pods since they're necessary to override constraints.
-		s.validateRestrictedLabels(ctx),
+		s.validateRestrictedLabels(),
 		s.Constraints.Validate(ctx),
 	)
 }
 
-func (s *ProvisionerSpec) validateRestrictedLabels(ctx context.Context) (errs *apis.FieldError) {
+func (s *ProvisionerSpec) validateRestrictedLabels() (errs *apis.FieldError) {
 	for key := range s.Labels {
 		if functional.ContainsString(RestrictedLabels, key) {
 			errs = errs.Also(apis.ErrInvalidKeyName(key, "labels"))
@@ -73,7 +73,7 @@ func (s *ProvisionerSpec) validateRestrictedLabels(ctx context.Context) (errs *a
 	return errs
 }
 
-func (s *ClusterSpec) validate(ctx context.Context) (errs *apis.FieldError) {
+func (s *ClusterSpec) validate() (errs *apis.FieldError) {
 	if s == nil {
 		return errs.Also(apis.ErrMissingField())
 	}
@@ -96,11 +96,11 @@ func (s *ClusterSpec) validate(ctx context.Context) (errs *apis.FieldError) {
 // be ignored for provisioning.
 func (c *Constraints) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(
-		c.validateLabels(ctx),
-		c.validateArchitecture(ctx),
-		c.validateOperatingSystem(ctx),
-		c.validateZones(ctx),
-		c.validateInstanceTypes(ctx),
+		c.validateLabels(),
+		c.validateArchitecture(),
+		c.validateOperatingSystem(),
+		c.validateZones(),
+		c.validateInstanceTypes(),
 	)
 	if ConstraintsValidationHook != nil {
 		errs = errs.Also(ConstraintsValidationHook(ctx, c))
@@ -108,7 +108,7 @@ func (c *Constraints) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-func (c *Constraints) validateLabels(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateLabels() (errs *apis.FieldError) {
 	for key, value := range c.Labels {
 		for _, err := range validation.IsQualifiedName(key) {
 			errs = errs.Also(apis.ErrInvalidKeyName(key, "labels", err))
@@ -120,7 +120,7 @@ func (c *Constraints) validateLabels(ctx context.Context) (errs *apis.FieldError
 	return errs
 }
 
-func (c *Constraints) validateArchitecture(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateArchitecture() (errs *apis.FieldError) {
 	if c.Architecture == nil {
 		return nil
 	}
@@ -130,7 +130,7 @@ func (c *Constraints) validateArchitecture(ctx context.Context) (errs *apis.Fiel
 	return errs
 }
 
-func (c *Constraints) validateOperatingSystem(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateOperatingSystem() (errs *apis.FieldError) {
 	if c.OperatingSystem == nil {
 		return nil
 	}
@@ -140,7 +140,7 @@ func (c *Constraints) validateOperatingSystem(ctx context.Context) (errs *apis.F
 	return errs
 }
 
-func (c *Constraints) validateZones(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateZones() (errs *apis.FieldError) {
 	for i, zone := range c.Zones {
 		if !functional.ContainsString(SupportedZones, zone) {
 			errs = errs.Also(apis.ErrInvalidArrayValue(fmt.Sprintf("%s not in %v", zone, SupportedZones), "zones", i))
@@ -149,7 +149,7 @@ func (c *Constraints) validateZones(ctx context.Context) (errs *apis.FieldError)
 	return errs
 }
 
-func (c *Constraints) validateInstanceTypes(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateInstanceTypes() (errs *apis.FieldError) {
 	for i, instanceType := range c.InstanceTypes {
 		if !functional.ContainsString(SupportedInstanceTypes, instanceType) {
 			errs = errs.Also(apis.ErrInvalidArrayValue(fmt.Sprintf("%s not in %v", instanceType, SupportedInstanceTypes), "instanceTypes", i))

--- a/pkg/apis/provisioning/v1alpha1/provisioner_validation_test.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner_validation_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Validation", func() {
 				ProvisionerNameLabelKey,
 				ProvisionerNamespaceLabelKey,
 				ProvisionerPhaseLabel,
-				ProvisionerTTLKey,
 				ZoneLabelKey,
 				InstanceTypeLabelKey,
 			} {

--- a/pkg/apis/provisioning/v1alpha1/provisioner_validation_test.go
+++ b/pkg/apis/provisioning/v1alpha1/provisioner_validation_test.go
@@ -65,22 +65,31 @@ var _ = Describe("Validation", func() {
 		}
 	})
 
-	It("should fail for restricted labels", func() {
-		for _, label := range []string{
-			ArchitectureLabelKey,
-			OperatingSystemLabelKey,
-			ProvisionerNameLabelKey,
-			ProvisionerNamespaceLabelKey,
-			ProvisionerPhaseLabel,
-			ProvisionerTTLKey,
-			ZoneLabelKey,
-			InstanceTypeLabelKey,
-		} {
-			provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
+	Context("Labels", func() {
+		It("should fail for invalid label keys", func() {
+			provisioner.Spec.Labels = map[string]string{"spaces are not allowed": randomdata.SillyName()}
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
-		}
+		})
+		It("should fail for invalid label values", func() {
+			provisioner.Spec.Labels = map[string]string{randomdata.SillyName(): "/ is not allowed"}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail for restricted labels", func() {
+			for _, label := range []string{
+				ArchitectureLabelKey,
+				OperatingSystemLabelKey,
+				ProvisionerNameLabelKey,
+				ProvisionerNamespaceLabelKey,
+				ProvisionerPhaseLabel,
+				ProvisionerTTLKey,
+				ZoneLabelKey,
+				InstanceTypeLabelKey,
+			} {
+				provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
+				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+			}
+		})
 	})
-
 	Context("Zones", func() {
 		SupportedZones = append(SupportedZones, "test-zone-1")
 		It("should succeed if unspecified", func() {

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -107,9 +107,12 @@ func (e *EC2API) DescribeSubnetsWithContext(context.Context, *ec2.DescribeSubnet
 		return e.DescribeSubnetsOutput, nil
 	}
 	return &ec2.DescribeSubnetsOutput{Subnets: []*ec2.Subnet{
-		{SubnetId: aws.String("test-subnet-1"), AvailabilityZone: aws.String("test-zone-1a")},
-		{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1b")},
-		{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1c")},
+		{SubnetId: aws.String("test-subnet-1"), AvailabilityZone: aws.String("test-zone-1a"),
+			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-1")}}},
+		{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1b"),
+			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
+		{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1c"),
+			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}, {Key: aws.String("TestTag")}}},
 	}}, nil
 }
 

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -101,7 +101,7 @@ func (p *LaunchTemplateProvider) Get(ctx context.Context, provisioner *v1alpha1.
 		return nil, fmt.Errorf("hashing launch template, %w", err)
 	}
 
-	result := &LaunchTemplate{Version: aws.String(defaultLaunchTemplateVersion)}
+	result := &LaunchTemplate{Version: aws.String(DefaultLaunchTemplateVersion)}
 	if cached, ok := p.cache.Get(fmt.Sprint(key)); ok {
 		result.Id = cached.(*ec2.LaunchTemplate).LaunchTemplateId
 		return result, nil

--- a/pkg/cloudprovider/aws/node.go
+++ b/pkg/cloudprovider/aws/node.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +72,10 @@ func (n *NodeFactory) nodeFrom(instance *ec2.Instance) *v1.Node {
 				v1.ResourcePods:   resource.MustParse("1000"),
 				v1.ResourceCPU:    resource.MustParse("96"),
 				v1.ResourceMemory: resource.MustParse("384Gi"),
+			},
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture: aws.StringValue(instance.Architecture),
+				OperatingSystem: v1alpha1.OperatingSystemLinux,
 			},
 		},
 	}

--- a/pkg/cloudprovider/registry/register.go
+++ b/pkg/cloudprovider/registry/register.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
-	"knative.dev/pkg/apis"
 )
 
 func NewCloudProvider(options cloudprovider.Options) cloudprovider.CloudProvider {
@@ -63,7 +62,5 @@ func RegisterOrDie(cloudProvider cloudprovider.CloudProvider) {
 	for operatingSystem := range operatingSystems {
 		v1alpha1.SupportedOperatingSystems = append(v1alpha1.SupportedOperatingSystems, operatingSystem)
 	}
-	v1alpha1.ValidationHook = func(ctx context.Context, spec *v1alpha1.ProvisionerSpec) *apis.FieldError {
-		return cloudProvider.Validate(ctx, spec)
-	}
+	v1alpha1.ConstraintsValidationHook = cloudProvider.Validate
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -31,8 +31,8 @@ type CloudProvider interface {
 	// GetInstanceTypes returns the instance types supported by the cloud
 	// provider limited by the provided constraints and daemons.
 	GetInstanceTypes(context.Context) ([]InstanceType, error)
-	// Validate cloud provider specific components of the cluster spec
-	Validate(context.Context, *v1alpha1.ProvisionerSpec) *apis.FieldError
+	// Validate is a hook for additional constraint validation logic specific to the cloud provider
+	Validate(context.Context, *v1alpha1.Constraints) *apis.FieldError
 	// Terminate nodes in cloudprovider
 	Terminate(context.Context, []*v1.Node) error
 }

--- a/pkg/controllers/provisioning/v1alpha1/reallocation/suite_test.go
+++ b/pkg/controllers/provisioning/v1alpha1/reallocation/suite_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Reallocation", func() {
 					v1alpha1.ProvisionerTTLKey: time.Now().Add(time.Duration(100) * time.Second).Format(time.RFC3339),
 				},
 			})
-			pod := test.PendingPodWith(test.PodOptions{
+			pod := test.Pod(test.PodOptions{
 				Name:       strings.ToLower(randomdata.SillyName()),
 				Namespace:  provisioner.Namespace,
 				NodeName:   node.Name,

--- a/pkg/controllers/terminating/v1alpha1/suite_test.go
+++ b/pkg/controllers/terminating/v1alpha1/suite_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Reallocation", func() {
 			})
 			ExpectCreatedWithStatus(env.Client, node)
 			ExpectCreated(env.Client, provisioner)
-			ExpectEventuallyDeleted(env.Client, node)
+			ExpectNotFound(env.Client, node)
 		})
 	})
 })

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -39,9 +39,9 @@ type PodOptions struct {
 
 // Pod creates a test pod with defaults that can be overriden by PodOptions.
 // Overrides are applied in order, with a last write wins semantic.
-func Pod(optionss ...PodOptions) *v1.Pod {
+func Pod(overrides ...PodOptions) *v1.Pod {
 	options := PodOptions{}
-	for _, opts := range optionss {
+	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
 			panic(fmt.Sprintf("Failed to merge pod options: %s", err.Error()))
 		}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Users may specify subnets using `node.k8s.aws/subnet-name: dns-compliant-name`
- Users may specify subnets using `node.k8s.aws/subnet-tag-key: kubernetes-label-compliant-tag-key-name`
- Added a bunch of validation and tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
