### PR TITLE
move lowest-n instance type options to generic packing pkg

### DIFF
--- a/pkg/packing/packer.go
+++ b/pkg/packing/packer.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	// maxInstanceTypes defines the number of instance type options to return to the cloud provider
+	maxInstanceTypes = 20
+)
+
 // Constraints for an efficient binpacking solution of pods onto nodes, given
 // overhead and node constraints.
 type Constraints struct {
@@ -103,6 +108,11 @@ func (p *packer) packWithLargestPod(unpackedPods []*v1.Pod, constraints *Constra
 		}
 	}
 	sortByResources(bestInstances)
+	// Trim the bestInstances so that provisioning APIs in cloud providers are not overwhelmed by the number of instance type options
+	// For example, the AWS EC2 Fleet API only allows the request to be 145kb which equates to about 130 instance type options.
+	if len(bestInstances) > maxInstanceTypes {
+		bestInstances = bestInstances[:maxInstanceTypes]
+	}
 	return &cloudprovider.Packing{Pods: bestPackedPods, Constraints: constraints.Constraints, InstanceTypeOptions: bestInstances}, remainingPods
 }
 

--- a/pkg/packing/packer.go
+++ b/pkg/packing/packer.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const (
-	// maxInstanceTypes defines the number of instance type options to return to the cloud provider
-	maxInstanceTypes = 20
+var (
+	// MaxInstanceTypes defines the number of instance type options to return to the cloud provider
+	MaxInstanceTypes = 20
 )
 
 // Constraints for an efficient binpacking solution of pods onto nodes, given
@@ -110,8 +110,8 @@ func (p *packer) packWithLargestPod(unpackedPods []*v1.Pod, constraints *Constra
 	sortByResources(bestInstances)
 	// Trim the bestInstances so that provisioning APIs in cloud providers are not overwhelmed by the number of instance type options
 	// For example, the AWS EC2 Fleet API only allows the request to be 145kb which equates to about 130 instance type options.
-	if len(bestInstances) > maxInstanceTypes {
-		bestInstances = bestInstances[:maxInstanceTypes]
+	if len(bestInstances) > MaxInstanceTypes {
+		bestInstances = bestInstances[:MaxInstanceTypes]
 	}
 	return &cloudprovider.Packing{Pods: bestPackedPods, Constraints: constraints.Constraints, InstanceTypeOptions: bestInstances}, remainingPods
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/karpenter/issues/438

Description of changes:
 - Move the truncation of instance type options from the cloud provider specific implementation to the generic packing pkg. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
