### PR TITLE
Resolved a race condition where provisioners could skip having defaults if applied before karpenter-webhook came online

### DIFF
--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -42,8 +42,6 @@ spec:
           ports:
             - name: webhook
               containerPort: 8443
-            - name: health-probe
-              containerPort: 8081
           livenessProbe:
             httpGet:
               scheme: HTTPS

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -46,8 +46,8 @@ spec:
               containerPort: 8081
           livenessProbe:
             httpGet:
-              path: /healthz
-              port: 8081
+              scheme: HTTPS
+              port: 8443
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/charts/karpenter/templates/webhook/webhooks.yaml
+++ b/charts/karpenter/templates/webhook/webhooks.yaml
@@ -3,39 +3,50 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.provisioners.karpenter.sh
 webhooks:
-  - admissionReviewVersions: ["v1"]
-    clientConfig:
-      service:
-        name: karpenter-webhook
-        namespace: '{{ .Release.Namespace }}'
-    failurePolicy: Fail
-    sideEffects: None
-    name: defaulting.webhook.provisioners.karpenter.sh
+- admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: karpenter-webhook
+      namespace: '{{ .Release.Namespace }}'
+  failurePolicy: Fail
+  sideEffects: None
+  name: defaulting.webhook.provisioners.karpenter.sh
+  rules:
+  - apiGroups:
+    - provisioning.karpenter.sh
+    apiVersions:
+    - v1alpha1
+    resources:
+    - provisioners
+      provisioners/status
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.provisioners.karpenter.sh
 webhooks:
-  - admissionReviewVersions: ["v1"]
-    clientConfig:
-      service:
-        name: karpenter-webhook
-        namespace: '{{ .Release.Namespace }}'
-    failurePolicy: Fail
-    sideEffects: None
-    name: validation.webhook.provisioners.karpenter.sh
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: validation.webhook.configmaps.karpenter.sh
-webhooks:
-  - admissionReviewVersions: ["v1"]
-    clientConfig:
-      service:
-        name: karpenter-webhook
-        namespace: '{{ .Release.Namespace }}'
-    failurePolicy: Ignore
-    sideEffects: None
-    name: validation.webhook.configmaps.karpenter.sh
+- admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: karpenter-webhook
+      namespace: '{{ .Release.Namespace }}'
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.provisioners.karpenter.sh
+  rules:
+  - apiGroups:
+    - provisioning.karpenter.sh
+    apiVersions:
+    - v1alpha1
+    resources:
+    - provisioners
+      provisioners/status
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE


### PR DESCRIPTION
Issue #, if available: #463

Description of changes:
The main change is that we now statically populate webhooks.yaml instead of allowing the webhook controller to inject the resources into the webhook. This ensures that the webhook configuration prevents creation of provisioners even if the webhook controller fails to come online (e.g. auth issues)

```rules:  - apiGroups:    - provisioning.karpenter.sh    apiVersions:    - v1alpha1    resources:    - provisioners      provisioners/status    operations:    - CREATE    - UPDATE    - DELETE```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
