### PR TITLE
add arch, os, and provisioner anti-affinities for the karpenter deployment

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -67,8 +67,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: provisioning.karpenter.sh/name
-                operator: DoesNotExist
               - key: kubernetes.io/arch
                 operator: In
                 values:

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -67,10 +67,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
               - key: kubernetes.io/os
                 operator: In
                 values:

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -59,10 +59,25 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.controller.affinity }}
+          {{- toYaml .Values.controller.affinity | nindent 8 }}
+        {{- else }}
+        nodeAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: provisioning.karpenter.sh/name
+                operator: DoesNotExist
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -69,8 +69,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: provisioning.karpenter.sh/name
-                operator: DoesNotExist
               - key: kubernetes.io/arch
                 operator: In
                 values:

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -61,10 +61,25 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.webhook.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.webhook.affinity }}
+          {{- toYaml .Values.webhook.affinity | nindent 8 }}
+        {{- else }}
+        nodeAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: provisioning.karpenter.sh/name
+                operator: DoesNotExist
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        {{- end }}
       {{- with .Values.webhook.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -69,10 +69,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
               - key: kubernetes.io/os
                 operator: In
                 values:


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
There are a few ways that karpenter pods can get scheduled on bad compute nodes:

1. Karpenter pods can be scheduled to nodes that were provisioned by karpenter which is not a good idea
2. Karpenter pods can be scheduled to Windows nodes which we do not publish a docker image for yet
3. Karpenter pods can be scheduled to arm64 nodes which we do not publish an image for yet

This PR adds a default anti-affinity for the karpenter provisioner name label (`provisioner.karpenter.sh/name`) and affinity to linux and amd64 nodes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
