### PR TITLE
Constraint subnets based on zones

### DIFF
--- a/pkg/cloudprovider/aws/subnets.go
+++ b/pkg/cloudprovider/aws/subnets.go
@@ -52,6 +52,10 @@ func (s *SubnetProvider) Get(ctx context.Context, provisioner *v1alpha1.Provisio
 	if tagKey := constraints.GetSubnetTagKey(); tagKey != nil {
 		subnets = filter(byTagKey(*tagKey), subnets)
 	}
+	// 4. Filter by zones if constrained
+	if len(constraints.Zones) != 0 {
+		subnets = filter(byZones(constraints.Zones), subnets)
+	}
 	return subnets, nil
 }
 
@@ -96,6 +100,17 @@ func byTagKey(tagKey string) func(*ec2.Subnet) bool {
 	return func(subnet *ec2.Subnet) bool {
 		for _, tag := range subnet.Tags {
 			if aws.StringValue(tag.Key) == tagKey {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func byZones(zones []string) func(*ec2.Subnet) bool {
+	return func(subnet *ec2.Subnet) bool {
+		for _, zone := range zones {
+			if aws.StringValue(subnet.AvailabilityZone) == zone {
 				return true
 			}
 		}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
We allow pods to be constrained to a particular zone by using this tag `topology.kubernetes.io/zone: us-east-2a`. However, we don't constraint the subnets when calling fleet API and instance gets created in the incorrect zone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
