### PR TITLE
Update toolchain script and make dep for docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ publish: ## Generate release manifests and publish a versioned container image.
 helm:  ## Generate Helm Chart
 	cd charts;helm lint karpenter;helm package karpenter;helm repo index .
 
-docs: ## Generate Docs
+docs: toolchain ## Generate Docs
 	gen-crd-api-reference-docs \
 		-api-dir ./pkg/apis/provisioning/v1alpha1 \
 		-config $(shell go env GOMODCACHE)/github.com/ahmetb/gen-crd-api-reference-docs@v0.2.0/example-config.json \

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 
@@ -7,14 +7,17 @@ trap "rm -rf $TEMP_DIR" EXIT
 
 main() {
     tools
-    kubebuilder
+    if ! command -v kubebuilder &>/dev/null; then
+        install_kubebuilder
+    fi
 }
 
 tools() {
-    cd tools; GO111MODULE=on cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % go install %
+    cd tools
+    GO111MODULE=on cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % go install %
 }
 
-kubebuilder() {
+install_kubebuilder() {
     os=$(go env GOOS)
     arch=$(go env GOARCH)
     curl -L "https://go.kubebuilder.io/dl/2.3.1/${os}/${arch}" | tar -xz -C $TEMP_DIR


### PR DESCRIPTION
Description of changes:

I added a check to see if `kubebuilder` is already installed before we install (and potentially override an existing binary).
I'm not sure if karpenter is tied to the 2.3.1 release of kubebuilder. I can update to the latest 3.1.0 (or latest) release if there are not specific requirements on 2.3.1.

If this breaks `make dev` we may not want to merge this but wanted to submit it as an option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
