### PR TITLE
Termination now only evicts pods that don't tolerate Unschedulable

### DIFF
--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -22,7 +22,6 @@ import (
 	"github.com/awslabs/karpenter/pkg/utils/functional"
 	"github.com/awslabs/karpenter/pkg/utils/pod"
 	"github.com/awslabs/karpenter/pkg/utils/ptr"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,16 +99,6 @@ func (f *Filter) matchesProvisioner(pod *v1.Pod, provisioner *v1alpha2.Provision
 		return nil
 	}
 	return fmt.Errorf("matched another provisioner, %s/%s", name, namespace)
-}
-
-func (f *Filter) toleratesTaints(p *v1.Pod, provisioner *v1alpha2.Provisioner) error {
-	var err error
-	for _, taint := range provisioner.Spec.Taints {
-		if err := pod.ToleratesTaints(&p.Spec, taint); err != nil {
-			err = multierr.Append(err, fmt.Errorf("did not tolerate %s=%s:%s", taint.Key, taint.Value, taint.Effect))
-		}
-	}
-	return err
 }
 
 func (f *Filter) withValidConstraints(ctx context.Context, pod *v1.Pod, provisioner *v1alpha2.Provisioner) error {

--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -49,7 +49,7 @@ func (f *Filter) GetProvisionablePods(ctx context.Context, provisioner *v1alpha2
 			func() error { return f.isUnschedulable(&p) },
 			func() error { return f.matchesProvisioner(&p, provisioner) },
 			func() error { return f.hasSupportedSchedulingConstraints(&p) },
-			func() error { return pod.ToleratesTaints(&p.Spec, provisioner.Spec.Taints) },
+			func() error { return pod.ToleratesTaints(&p.Spec, provisioner.Spec.Taints...) },
 			func() error { return f.withValidConstraints(ctx, &p, provisioner) },
 		); err != nil {
 			zap.S().Debugf("Ignored pod %s/%s when allocating for provisioner %s/%s, %s",

--- a/pkg/controllers/reallocation/utilization.go
+++ b/pkg/controllers/reallocation/utilization.go
@@ -32,24 +32,6 @@ type Utilization struct {
 	kubeClient client.Client
 }
 
-func (u *Utilization) Reconcile(ctx context.Context, provisioner *v1alpha2.Provisioner) error {
-	// 1. Set TTL on TTLable Nodes
-	if err := u.markUnderutilized(ctx, provisioner); err != nil {
-		return fmt.Errorf("adding ttl and underutilized label, %w", err)
-	}
-
-	// 2. Remove TTL from Utilized Nodes
-	if err := u.clearUnderutilized(ctx, provisioner); err != nil {
-		return fmt.Errorf("removing ttl from node, %w", err)
-	}
-
-	// 3. Mark any Node past TTL as expired
-	if err := u.terminateExpired(ctx, provisioner); err != nil {
-		return fmt.Errorf("marking nodes terminable, %w", err)
-	}
-	return nil
-}
-
 // markUnderutilized adds a TTL to underutilized nodes
 func (u *Utilization) markUnderutilized(ctx context.Context, provisioner *v1alpha2.Provisioner) error {
 	ttlable := []*v1.Node{}

--- a/pkg/controllers/reallocation/utilization.go
+++ b/pkg/controllers/reallocation/utilization.go
@@ -111,6 +111,7 @@ func (u *Utilization) terminateExpired(ctx context.Context, provisioner *v1alpha
 	}
 
 	// 2. Delete node if past TTL
+	// This will kick off work for the termination controller to gracefully shut down the node.
 	for _, node := range nodes {
 		if utilsnode.IsPastTTL(node) {
 			if err := u.kubeClient.Delete(ctx, node); err != nil {

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -70,7 +70,7 @@ func (c *Controller) Reconcile(ctx context.Context, object client.Object) (recon
 	// 4. If fully drained, terminate the node
 	if drained {
 		if err := c.terminator.terminate(ctx, node); err != nil {
-			return reconcile.Result{}, fmt.Errorf("terminating nodes, %w", err)
+			return reconcile.Result{}, fmt.Errorf("terminating node %s, %w", node.Name, err)
 		}
 	}
 	return reconcile.Result{Requeue: !drained}, nil

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -82,10 +82,10 @@ var _ = Describe("Termination", func() {
 		})
 		It("should not evict pods that tolerate unschedulable taint", func() {
 			node := test.NodeWith(test.NodeOptions{
-				Finalizers: []string{v1alpha1.KarpenterFinalizer},
+				Finalizers: []string{v1alpha2.KarpenterFinalizer},
 				Labels: map[string]string{
-					v1alpha1.ProvisionerNameLabelKey:      "default",
-					v1alpha1.ProvisionerNamespaceLabelKey: "default",
+					v1alpha2.ProvisionerNameLabelKey:      "default",
+					v1alpha2.ProvisionerNamespaceLabelKey: "default",
 				},
 			})
 			pod := test.Pod(test.PodOptions{

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -94,11 +94,10 @@ var _ = Describe("Termination", func() {
 			})
 			ExpectCreatedWithStatus(env.Client, node)
 			ExpectCreatedWithStatus(env.Client, pod)
-
-			newPods := &v1.PodList{}
+			pods := &v1.PodList{}
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
-			Expect(env.Client.List(ctx, newPods, client.MatchingFields{"spec.nodeName": node.Name})).To(Succeed())
-			Expect(newPods.Items).To(HaveLen(1))
+			Expect(env.Client.List(ctx, pods, client.MatchingFields{"spec.nodeName": node.Name})).To(Succeed())
+			Expect(pods.Items).To(HaveLen(1))
 			ExpectNotFound(env.Client, node)
 		})
 	})

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Termination", func() {
 			})
 			ExpectCreatedWithStatus(env.Client, node)
 			ExpectCreatedWithStatus(env.Client, pod)
+
 			pods := &v1.PodList{}
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			Expect(env.Client.List(ctx, pods, client.MatchingFields{"spec.nodeName": node.Name})).To(Succeed())

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider/fake"
 	"github.com/awslabs/karpenter/pkg/cloudprovider/registry"
 	"github.com/awslabs/karpenter/pkg/test"
+	v1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	. "github.com/awslabs/karpenter/pkg/test/expectations"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAPIs(t *testing.T) {
@@ -76,6 +78,27 @@ var _ = Describe("Termination", func() {
 			})
 			ExpectCreatedWithStatus(env.Client, node)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			ExpectNotFound(env.Client, node)
+		})
+		It("should not evict pods that tolerate unschedulable taint", func() {
+			node := test.NodeWith(test.NodeOptions{
+				Finalizers: []string{v1alpha1.KarpenterFinalizer},
+				Labels: map[string]string{
+					v1alpha1.ProvisionerNameLabelKey:      "default",
+					v1alpha1.ProvisionerNamespaceLabelKey: "default",
+				},
+			})
+			pod := test.Pod(test.PodOptions{
+				NodeName:    node.Name,
+				Tolerations: []v1.Toleration{{Key: v1.TaintNodeUnschedulable, Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectCreatedWithStatus(env.Client, pod)
+
+			newPods := &v1.PodList{}
+			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			Expect(env.Client.List(ctx, newPods, client.MatchingFields{"spec.nodeName": node.Name})).To(Succeed())
+			Expect(newPods.Items).To(HaveLen(1))
 			ExpectNotFound(env.Client, node)
 		})
 	})

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -40,9 +40,11 @@ type Terminator struct {
 
 // cordon cordons a node
 func (t *Terminator) cordon(ctx context.Context, node *v1.Node) error {
+	// 1. Check if node is already cordoned
 	if node.Spec.Unschedulable {
 		return nil
 	}
+	// 2. Cordon node
 	persisted := node.DeepCopy()
 	node.Spec.Unschedulable = true
 	if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
@@ -52,28 +54,33 @@ func (t *Terminator) cordon(ctx context.Context, node *v1.Node) error {
 	return nil
 }
 
-// drain evicts pods from the node and returns true when fully drained
+// drain evicts pods from the node and returns true when all pods are evicted
 func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 	// 1. Get pods on node
 	pods, err := t.getPods(ctx, node)
 	if err != nil {
 		return false, fmt.Errorf("listing pods for node %s, %w", node.Name, err)
 	}
-	// 2. Evict pods on node
-	empty := true
-	for _, p := range pods {
-		if !pod.IsOwnedByDaemonSet(p) {
-			empty = false
-			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: p.Name,
-				},
-			}); err != nil {
-				zap.S().Debugf("Continuing after failing to evict pods from node %s, %s", node.Name, err.Error())
-			}
+	// 2. Separate pods as non-critical and critical
+	// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+	nonCritical := []*v1.Pod{}
+	critical := []*v1.Pod{}
+	for _, pod := range pods {
+		if pod.Spec.PriorityClassName == "system-cluster-critical" || pod.Spec.PriorityClassName == "system-node-critical" {
+			critical = append(critical, pod)
+		} else {
+			nonCritical = append(nonCritical, pod)
 		}
 	}
-	return empty, nil
+	// 3. Evict non-critical0 pods
+	if !t.evictPods(ctx, nonCritical) {
+		return false, nil
+	}
+	// 4. Evict critical pods once all non-critical pods are evicted
+	if !t.evictPods(ctx, critical) {
+		return false, nil
+	}
+	return true, nil
 }
 
 // terminate terminates the node then removes the finalizer to delete the node
@@ -92,7 +99,27 @@ func (t *Terminator) terminate(ctx context.Context, node *v1.Node) error {
 	return nil
 }
 
-// getPods returns a list of pods scheduled to a node
+// evictPods returns true if there are no evictable pods
+func (t *Terminator) evictPods(ctx context.Context, pods []*v1.Pod) bool {
+	empty := true
+	for _, p := range pods {
+		// If a pod tolerates the unschedulable taint, don't evict it as it could reschedule back onto the node
+		if err := pod.ToleratesTaints(&p.Spec, []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}); err != nil {
+			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: p.Name,
+				},
+			}); err != nil {
+				// If an eviction fails, we need to eventually try again
+				zap.S().Debugf("Continuing after failing to evict pod %s from node %s, %s", p.Name, p.Spec.NodeName, err.Error())
+				empty = false
+			}
+		}
+	}
+	return empty
+}
+
+// getPods returns a list of pods scheduled to a node based on some filters
 func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, error) {
 	pods := &v1.PodList{}
 	if err := t.kubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -105,7 +105,7 @@ func (t *Terminator) evictPods(ctx context.Context, pods []*v1.Pod) bool {
 	for _, p := range pods {
 		// If a pod tolerates the unschedulable taint, don't evict it as it could reschedule back onto the node
 		if err := pod.ToleratesTaints(&p.Spec, v1.Taint{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}); err != nil {
-			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{ ObjectMeta: metav1.ObjectMeta{ Name: p.Name }}); err != nil {
+			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: p.Name}}); err != nil {
 				// If an eviction fails, we need to eventually try again
 				zap.S().Debugf("Continuing after failing to evict pod %s from node %s, %s", p.Name, p.Spec.NodeName, err.Error())
 				empty = false

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -72,7 +72,7 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 			nonCritical = append(nonCritical, pod)
 		}
 	}
-	// 3. Evict non-critical0 pods
+	// 3. Evict non-critical pods
 	if !t.evictPods(ctx, nonCritical) {
 		return false, nil
 	}
@@ -104,12 +104,8 @@ func (t *Terminator) evictPods(ctx context.Context, pods []*v1.Pod) bool {
 	empty := true
 	for _, p := range pods {
 		// If a pod tolerates the unschedulable taint, don't evict it as it could reschedule back onto the node
-		if err := pod.ToleratesTaints(&p.Spec, []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}); err != nil {
-			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: p.Name,
-				},
-			}); err != nil {
+		if err := pod.ToleratesTaints(&p.Spec, v1.Taint{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}); err != nil {
+			if err := t.coreV1Client.Pods(p.Namespace).Evict(ctx, &v1beta1.Eviction{ ObjectMeta: metav1.ObjectMeta{ Name: p.Name }}); err != nil {
 				// If an eviction fails, we need to eventually try again
 				zap.S().Debugf("Continuing after failing to evict pod %s from node %s, %s", p.Name, p.Spec.NodeName, err.Error())
 				empty = false

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -47,8 +47,7 @@ func IsSchedulable(pod *v1.PodSpec, node *v1.Node) bool {
 
 // ToleratesTaints returns an error if the pod does not tolerate the taints
 // https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
-func ToleratesTaints(spec *v1.PodSpec, taints ...v1.Taint) error {
-	var err error
+func ToleratesTaints(spec *v1.PodSpec, taints ...v1.Taint) (err error) {
 	for _, taint := range taints {
 		if !Tolerates(spec.Tolerations, taint) {
 			err = multierr.Append(err, fmt.Errorf("did not tolerate %s=%s:%s", taint.Key, taint.Value, taint.Effect))


### PR DESCRIPTION
Issue #, if available:
When draining nodes, we did not gracefully evict any daemonset pods, but left them to forcefully terminate along with the node, when no other pods remained. 

Description of changes:
- This change makes it so that we evict all pods that won't be rescheduled even if the node is cordoned (tolerates unschedulable)
- Additionally, I remove the duplicated un-used Reconcile() function in the Reallocation controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
