### PR TITLE
Added note in placeholder README.md to account for 404

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -21,6 +21,7 @@ Karpenter can run anywhere, including on self-managed node groups, [managed node
 This demo will run Karpenter on Fargate, which means all EC2 instances added to this cluster will be controlled by Karpenter.
 
 ```bash
+# If the following URL gives a 404, use https://raw.githubusercontent.com/awslabs/karpenter/main/docs/aws/eks-config.yaml
 curl -fsSL https://raw.githubusercontent.com/awslabs/karpenter/"${KARPENTER_VERSION}"/docs/aws/eks-config.yaml \
   | envsubst \
   | eksctl create cluster -f -


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The current README.md pulls the eks-config.yaml file from the most recent release. Since the commit to add this file in came after the release, this will result in a 404 until we cut another release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
