### PR TITLE
Finally decided to prevent tests from flaking 🤷

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -424,5 +424,5 @@ its target, and indicates whether or not those conditions are met.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>aa1e430</code>.
+on git commit <code>bf03801</code>.
 </em></p>

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -18,11 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/karpenter/pkg/utils/conditions"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -50,15 +48,6 @@ func (c *GenericController) Reconcile(ctx context.Context, req reconcile.Request
 	result, err := c.Controller.Reconcile(ctx, resource)
 	if err != nil {
 		zap.S().Errorf("Controller failed to reconcile kind %s, %s", resource.GetObjectKind().GroupVersionKind().Kind, err.Error())
-	}
-	// 4. Set status based on results of reconcile
-	if conditionsAccessor, ok := resource.(apis.ConditionsAccessor); ok {
-		m := apis.NewLivingConditionSet(conditions.Active).Manage(conditionsAccessor)
-		if err != nil {
-			m.MarkFalse(conditions.Active, err.Error(), "")
-		} else {
-			m.MarkTrue(conditions.Active)
-		}
 	}
 	// 5. Update Status using a merge patch
 	// If the controller is reconciling nodes, don't patch

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -19,12 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/awslabs/karpenter/pkg/apis"
-
 	"golang.org/x/time/rate"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -34,22 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var (
-	scheme = runtime.NewScheme()
-)
-
-func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = apis.AddToScheme(scheme)
-}
-
 type GenericControllerManager struct {
 	manager.Manager
 }
 
 // NewManagerOrDie instantiates a controller manager or panics
 func NewManagerOrDie(config *rest.Config, options controllerruntime.Options) Manager {
-	options.Scheme = scheme
 	manager, err := controllerruntime.NewManager(config, options)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create controller manager, %s", err.Error()))


### PR DESCRIPTION
Issue #382, if available:

Description of changes:
- Tests now run in ~40 seconds instead of 1:20
- Now calls reconcilers directly to make tests more deterministic. Previous approach launched the controllers and waited, which frequently was subject to GHA noisy neighbors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
