### PR TITLE
Added do-not-evict option for pods

### DIFF
--- a/pkg/apis/provisioning/v1alpha2/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha2/provisioner.go
@@ -120,7 +120,8 @@ var (
 	ProvisionerUnderutilizedLabelKey = SchemeGroupVersion.Group + "/underutilized"
 
 	// Reserved annotations
-	ProvisionerTTLKey = SchemeGroupVersion.Group + "/ttl"
+	ProvisionerTTLKey                = SchemeGroupVersion.Group + "/ttl"
+	KarpenterDoNotEvictPodAnnotation = "karpenter.sh/do-not-evict"
 
 	// Use ProvisionerSpec instead
 	ZoneLabelKey         = "topology.kubernetes.io/zone"

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -55,7 +55,7 @@ func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface
 func (c *Controller) Reconcile(ctx context.Context, object client.Object) (reconcile.Result, error) {
 	node := object.(*v1.Node)
 	// 1. Check if node is terminable
-	if node.DeletionTimestamp == nil || !functional.ContainsString(node.Finalizers, provisioning.KarpenterFinalizer) {
+	if node.DeletionTimestamp.IsZero() || !functional.ContainsString(node.Finalizers, provisioning.KarpenterFinalizer) {
 		return reconcile.Result{}, nil
 	}
 	// 2. Cordon node

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -35,6 +35,7 @@ type PodOptions struct {
 	NodeSelector         map[string]string
 	Tolerations          []v1.Toleration
 	Conditions           []v1.PodCondition
+	Annotations          map[string]string
 }
 
 // Pod creates a test pod with defaults that can be overriden by PodOptions.
@@ -60,6 +61,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 			Name:            options.Name,
 			Namespace:       options.Namespace,
 			OwnerReferences: options.OwnerReferences,
+			Annotations:     options.Annotations,
 		},
 		Spec: v1.PodSpec{
 			NodeSelector: options.NodeSelector,


### PR DESCRIPTION
**Issue, if available:**


**Description of changes:**
- Users can now specify annotations on their pods `karpenter.sh/do-not-evict` where requesting to terminate that node will cordon it, but wait to drain until those pods are terminated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
