### PR TITLE
Added Per-pod eviction backoff and retry logic 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/aws/aws-sdk-go v1.38.69
+	github.com/deckarep/golang-set v1.7.1
 	github.com/go-logr/zapr v0.4.0
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
 github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -41,21 +41,16 @@ type Controller struct {
 	KubeClient client.Client
 }
 
-// For returns the resource this controller is for.
-func (c *Controller) For() client.Object {
-	return &v1.Node{}
-}
-
-func (c *Controller) Name() string {
-	return "terminator"
-}
-
 // NewController constructs a controller instance
 func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider) *Controller {
 	return &Controller{
 		KubeClient: kubeClient,
-		Terminator: NewTerminator(kubeClient, coreV1Client, cloudProvider,
-			workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(evictionQueueBaseDelay, evictionQueueMaxDelay))),
+		Terminator: &Terminator{
+			KubeClient:    kubeClient,
+			CoreV1Client:  coreV1Client,
+			CloudProvider: cloudProvider,
+			EvictionQueue: NewEvictionQueue(coreV1Client),
+		},
 	}
 }
 

--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -1,0 +1,93 @@
+package termination
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	set "github.com/deckarep/golang-set"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type EvictionQueue struct {
+	Queue        workqueue.DelayingInterface
+	RateLimiter  workqueue.RateLimiter
+	coreV1Client corev1.CoreV1Interface
+
+	enqueued set.Set
+	once     sync.Once
+}
+
+// Evict adds a pod to the EvictionQueue
+func (e *EvictionQueue) Add(pods []*v1.Pod) {
+	e.once.Do(func() { go e.run() })
+
+	for _, pod := range pods {
+		if !e.enqueued.Contains(pod) {
+			zap.S().Debugf("DEBUGGING: Enqueued pod %s", pod.Name)
+			e.enqueued.Add(pod)
+			e.Queue.Add(pod)
+		}
+	}
+}
+
+func (e *EvictionQueue) run() {
+	for {
+		if e.Queue.Len() == 0 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		// Get pod from queue
+		item, shutdown := e.Queue.Get()
+		if shutdown {
+			zap.S().Infof("Shutdown queue is broken")
+		}
+		pod, ok := item.(*v1.Pod)
+		if !ok {
+			panic("Item is not pod")
+		}
+		// Evict pod
+		success := e.evict(pod)
+		if success {
+			zap.S().Debugf("Successfully evicted pod %s", pod.Name)
+			e.Queue.Done(item)
+			e.RateLimiter.Forget(item)
+			e.enqueued.Remove(item)
+			continue
+		}
+		// Requeue pod if failed
+		zap.S().Debugf("DEBUGGING: this is the num of failures for pod %s: %d", pod.Name, e.RateLimiter.NumRequeues(item))
+		e.Queue.AddAfter(item, e.RateLimiter.When(item))
+	}
+}
+
+// returns true if successful eviction call, error is returned if not eviction-related error
+func (e *EvictionQueue) evict(pod *v1.Pod) bool {
+	err := e.coreV1Client.Pods(pod.Namespace).Evict(context.Background(), &v1beta1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+	})
+	// 500
+	if errors.IsInternalError(err) {
+		zap.S().Debugf("Failed to evict pod %s due to misconfiguration error.", pod.Name)
+		return false
+	}
+	// 429
+	if errors.IsTooManyRequests(err) {
+		zap.S().Debugf("Failed to evict pod %s due to PDB violation", pod.Name)
+		return false
+	}
+	// 404
+	if errors.IsNotFound(err) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package termination
 
 import (
@@ -14,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -44,7 +59,7 @@ func (e *EvictionQueue) Add(pods []*v1.Pod) {
 	e.once.Do(func() { go e.run() })
 
 	for _, pod := range pods {
-		if nn := (types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}); !e.Set.Contains(nn) {
+		if nn := client.ObjectKeyFromObject(pod); !e.Set.Contains(nn) {
 			e.Set.Add(nn)
 			e.RateLimitingInterface.Add(nn)
 		}

--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -3,7 +3,6 @@ package termination
 import (
 	"context"
 	"sync"
-	"time"
 
 	set "github.com/deckarep/golang-set"
 	"go.uber.org/zap"
@@ -11,13 +10,13 @@ import (
 	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
 )
 
 type EvictionQueue struct {
-	Queue        workqueue.DelayingInterface
-	RateLimiter  workqueue.RateLimiter
+	queue        workqueue.RateLimitingInterface
 	coreV1Client corev1.CoreV1Interface
 
 	enqueued set.Set
@@ -26,64 +25,59 @@ type EvictionQueue struct {
 
 // Evict adds a pod to the EvictionQueue
 func (e *EvictionQueue) Add(pods []*v1.Pod) {
+	// Start processing eviction queue if it hasn't started already
 	e.once.Do(func() { go e.run() })
 
 	for _, pod := range pods {
-		if !e.enqueued.Contains(pod) {
-			zap.S().Debugf("DEBUGGING: Enqueued pod %s", pod.Name)
-			e.enqueued.Add(pod)
-			e.Queue.Add(pod)
+		nn := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+		if !e.enqueued.Contains(nn) {
+			e.enqueued.Add(nn)
+			e.queue.Add(nn)
 		}
 	}
 }
 
 func (e *EvictionQueue) run() {
 	for {
-		if e.Queue.Len() == 0 {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-		// Get pod from queue
-		item, shutdown := e.Queue.Get()
+		// Get pod from queue. This waits until queue is non-empty.
+		item, shutdown := e.queue.Get()
 		if shutdown {
 			zap.S().Infof("Shutdown queue is broken")
 		}
-		pod, ok := item.(*v1.Pod)
-		if !ok {
-			panic("Item is not pod")
-		}
+		// Panic if not a NamespacedName
+		nn := item.(types.NamespacedName)
 		// Evict pod
-		success := e.evict(pod)
-		if success {
-			zap.S().Debugf("Successfully evicted pod %s", pod.Name)
-			e.Queue.Done(item)
-			e.RateLimiter.Forget(item)
-			e.enqueued.Remove(item)
+		evicted := e.evict(nn)
+		e.queue.Done(nn)
+		if evicted {
+			zap.S().Debugf("Successfully evicted pod %s", nn.String())
+			e.queue.Forget(nn)
+			e.enqueued.Remove(nn)
 			continue
 		}
-		// Requeue pod if failed
-		zap.S().Debugf("DEBUGGING: this is the num of failures for pod %s: %d", pod.Name, e.RateLimiter.NumRequeues(item))
-		e.Queue.AddAfter(item, e.RateLimiter.When(item))
+		// Requeue pod if eviction failed
+		e.queue.AddRateLimited(nn)
 	}
 }
 
 // returns true if successful eviction call, error is returned if not eviction-related error
-func (e *EvictionQueue) evict(pod *v1.Pod) bool {
-	err := e.coreV1Client.Pods(pod.Namespace).Evict(context.Background(), &v1beta1.Eviction{
-		ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+func (e *EvictionQueue) evict(nn types.NamespacedName) bool {
+	err := e.coreV1Client.Pods(nn.Namespace).Evict(context.Background(), &v1beta1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
 	})
 	// 500
 	if errors.IsInternalError(err) {
-		zap.S().Debugf("Failed to evict pod %s due to misconfiguration error.", pod.Name)
+		zap.S().Debugf("Failed to evict pod %s due to PDB misconfiguration error. Backing off then trying again.", nn.String())
 		return false
 	}
 	// 429
 	if errors.IsTooManyRequests(err) {
-		zap.S().Debugf("Failed to evict pod %s due to PDB violation", pod.Name)
+		zap.S().Debugf("Failed to evict pod %s due to PDB violation. Backing off then trying again.", nn.String())
 		return false
 	}
 	// 404
 	if errors.IsNotFound(err) {
+		zap.S().Debugf("Continuing after failing to evict pod %s since it was not found.", nn.String())
 		return true
 	}
 	if err != nil {

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -43,9 +43,11 @@ var controller *termination.Controller
 var env = test.NewEnvironment(func(e *test.Environment) {
 	cloudProvider := &fake.CloudProvider{}
 	registry.RegisterOrDie(cloudProvider)
-	coreV1Client := corev1.NewForConfigOrDie(e.Config)
-	controller = termination.NewControllerWithCustomQueue(e.Client, coreV1Client, cloudProvider,
-		workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Microsecond, 10*time.Microsecond)))
+	controller = &termination.Controller{
+		KubeClient: e.Client,
+		Terminator: termination.NewTerminator(e.Client, corev1.NewForConfigOrDie(e.Config), cloudProvider,
+			workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Microsecond, 10*time.Microsecond))),
+	}
 })
 
 var _ = BeforeSuite(func() {

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -107,7 +108,7 @@ func (t *Terminator) terminate(ctx context.Context, node *v1.Node) error {
 	// 2. Remove finalizer from node in APIServer
 	persisted := node.DeepCopy()
 	node.Finalizers = functional.StringSliceWithout(node.Finalizers, provisioning.KarpenterFinalizer)
-	if err := t.KubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
+	if err := t.KubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("removing finalizer from node %s, %w", node.Name, err)
 	}
 	return nil

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/ptr"
@@ -87,6 +88,11 @@ func ExpectDeleted(c client.Client, objects ...client.Object) {
 
 func ExpectCleanedUp(c client.Client) {
 	ctx := context.Background()
+	pdbs := v1beta1.PodDisruptionBudgetList{}
+	Expect(c.List(ctx, &pdbs)).To(Succeed())
+	for _, pdb := range pdbs.Items {
+		ExpectDeleted(c, &pdb)
+	}
 	pods := v1.PodList{}
 	Expect(c.List(ctx, &pods)).To(Succeed())
 	for _, pod := range pods.Items {

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -42,11 +42,11 @@ type PodOptions struct {
 }
 
 type PDBOptions struct {
-	Name           string
-	Namespace      string
-	MinAvailable   *intstr.IntOrString
-	Selector       *metav1.LabelSelector
-	MaxUnavailable *intstr.IntOrString
+	Name              string
+	Namespace         string
+	MinAvailableNum   *int64
+	Labels            map[string]string
+	MaxUnavailableNum *int64
 }
 
 // Pod creates a test pod with defaults that can be overriden by PodOptions.
@@ -109,15 +109,24 @@ func PodDisruptionBudget(overrides ...PDBOptions) *v1beta1.PodDisruptionBudget {
 	if options.Namespace == "" {
 		options.Namespace = "default"
 	}
+	var minAvailable, maxUnavailable *intstr.IntOrString
+	if options.MinAvailableNum != nil {
+		minAvailable = intstr.ValueOrDefault(nil, intstr.FromInt(int(*options.MinAvailableNum)))
+	}
+	if options.MaxUnavailableNum != nil {
+		maxUnavailable = intstr.ValueOrDefault(nil, intstr.FromInt(int(*options.MaxUnavailableNum)))
+	}
 	return &v1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      options.Name,
 			Namespace: options.Namespace,
 		},
 		Spec: v1beta1.PodDisruptionBudgetSpec{
-			MinAvailable:   options.MinAvailable,
-			Selector:       options.Selector,
-			MaxUnavailable: options.MaxUnavailable,
+			MinAvailable: minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: options.Labels,
+			},
+			MaxUnavailable: maxUnavailable,
 		},
 	}
 }

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -21,7 +21,9 @@ import (
 	"github.com/Pallinder/go-randomdata"
 	"github.com/imdario/mergo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // PodOptions customizes a Pod.
@@ -36,6 +38,15 @@ type PodOptions struct {
 	Tolerations          []v1.Toleration
 	Conditions           []v1.PodCondition
 	Annotations          map[string]string
+	Labels               map[string]string
+}
+
+type PDBOptions struct {
+	Name           string
+	Namespace      string
+	MinAvailable   *intstr.IntOrString
+	Selector       *metav1.LabelSelector
+	MaxUnavailable *intstr.IntOrString
 }
 
 // Pod creates a test pod with defaults that can be overriden by PodOptions.
@@ -62,6 +73,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 			Namespace:       options.Namespace,
 			OwnerReferences: options.OwnerReferences,
 			Annotations:     options.Annotations,
+			Labels:          options.Labels,
 		},
 		Spec: v1.PodSpec{
 			NodeSelector: options.NodeSelector,
@@ -82,4 +94,30 @@ func PendingPod(options ...PodOptions) *v1.Pod {
 	return Pod(append(options, PodOptions{
 		Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Reason: v1.PodReasonUnschedulable, Status: v1.ConditionFalse}},
 	})...)
+}
+
+func PodDisruptionBudget(overrides ...PDBOptions) *v1beta1.PodDisruptionBudget {
+	options := PDBOptions{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge pod options: %s", err.Error()))
+		}
+	}
+	if options.Name == "" {
+		options.Name = strings.ToLower(randomdata.SillyName())
+	}
+	if options.Namespace == "" {
+		options.Namespace = "default"
+	}
+	return &v1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      options.Name,
+			Namespace: options.Namespace,
+		},
+		Spec: v1beta1.PodDisruptionBudgetSpec{
+			MinAvailable:   options.MinAvailable,
+			Selector:       options.Selector,
+			MaxUnavailable: options.MaxUnavailable,
+		},
+	}
 }


### PR DESCRIPTION
**Issue, if available:**
https://github.com/awslabs/karpenter/issues/452

**Description of changes:**
- Pod evictions now have separate backoffs per pod
- Drain in termination controller queues up pods to a continually running queue processor as a goroutine in the background
- Accounts for different pod eviction errors 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
