### PR TITLE
Limit "provisioner does not exist" logging and fix startup reconciliation bug

### DIFF
--- a/pkg/apis/provisioning/v1alpha3/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha3/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/utils/functional"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ProvisionerSpec is the top level provisioner specification. Provisioners
@@ -130,6 +131,9 @@ var (
 
 	// Finalizers
 	KarpenterFinalizer = SchemeGroupVersion.Group + "/termination"
+
+	// Default provisioner
+	DefaultProvisioner = types.NamespacedName{Name: "default"}
 )
 
 // Provisioner is the Schema for the Provisioners API

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -16,7 +16,6 @@ package aws
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -62,7 +61,7 @@ var env = test.NewEnvironment(func(e *test.Environment) {
 			fakeEC2API,
 			NewAMIProvider(&fake.SSMAPI{}, clientSet),
 			NewSecurityGroupProvider(fakeEC2API),
-			cache.New(CacheTTL, CacheCleanupInterval),
+			launchTemplateCache,
 		},
 		subnetProvider:       NewSubnetProvider(fakeEC2API),
 		instanceTypeProvider: NewInstanceTypeProvider(fakeEC2API),
@@ -96,8 +95,7 @@ var _ = Describe("Allocation", func() {
 		ctx = context.Background()
 		provisioner = &v1alpha3.Provisioner{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      strings.ToLower(randomdata.SillyName()),
-				Namespace: "default",
+				Name: v1alpha3.DefaultProvisioner.Name,
 			},
 			Spec: v1alpha3.ProvisionerSpec{
 				Cluster: v1alpha3.Cluster{

--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.Batcher.Wait(&v1alpha3.Provisioner{})
-			zap.S().Errorf("Provisioner \"%s\" not found. Create the 'default' provisioner or specify an alternative using the nodeSelector %s", req.Name, v1alpha3.ProvisionerNameLabelKey)
+			zap.S().Errorf("Provisioner \"%s\" not found. Create the \"default\" provisioner or specify an alternative using the nodeSelector %s", req.Name, v1alpha3.ProvisionerNameLabelKey)
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.Batcher.Wait(&v1alpha3.Provisioner{})
-			zap.S().Errorf("No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector %s", v1alpha3.ProvisionerNameLabelKey)
+			zap.S().Errorf("Provisioner \"%s\" not found. Create the 'default' provisioner or specify an alternative using the nodeSelector %s", req.Name, v1alpha3.ProvisionerNameLabelKey)
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -144,15 +144,9 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 			// Only process pod update events
 			builder.WithPredicates(
 				predicate.Funcs{
-					CreateFunc: func(_ event.CreateEvent) bool {
-						return false
-					},
-					DeleteFunc: func(_ event.DeleteEvent) bool {
-						return false
-					},
-					GenericFunc: func(_ event.GenericEvent) bool {
-						return false
-					},
+					CreateFunc:  func(_ event.CreateEvent) bool { return false },
+					DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+					GenericFunc: func(_ event.GenericEvent) bool { return false },
 				},
 			),
 		).
@@ -199,7 +193,11 @@ func (c *Controller) podToProvisioner(o client.Object) (requests []reconcile.Req
 			// Queue and batch a reconcile request for a non-existent, empty provisioner
 			// This will reduce the number of repeated error messages about a provisioner not existing
 			c.Batcher.Add(&v1alpha3.Provisioner{})
-			return []reconcile.Request{{NamespacedName: types.NamespacedName{}}}
+			notFoundProvisioner := v1alpha3.DefaultProvisioner.Name
+			if name, ok := pod.Spec.NodeSelector[v1alpha3.ProvisionerNameLabelKey]; ok {
+				notFoundProvisioner = name
+			}
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: notFoundProvisioner}}}
 		}
 		return nil
 	}
@@ -213,7 +211,7 @@ func (c *Controller) podToProvisioner(o client.Object) (requests []reconcile.Req
 // getProvisionerFor retrieves the provisioner responsible for the pod
 func (c *Controller) getProvisionerFor(ctx context.Context, p *v1.Pod) (*v1alpha3.Provisioner, error) {
 	if err := c.Filter.isUnschedulable(p); err != nil {
-		return nil, fmt.Errorf("pod is not eligible to be associated with a provisioner")
+		return nil, err
 	}
 	provisionerKey := v1alpha3.DefaultProvisioner
 	if name, ok := p.Spec.NodeSelector[v1alpha3.ProvisionerNameLabelKey]; ok {

--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -88,14 +88,11 @@ func (f *Filter) hasSupportedSchedulingConstraints(pod *v1.Pod) error {
 }
 
 func (f *Filter) matchesProvisioner(pod *v1.Pod, provisioner *v1alpha3.Provisioner) error {
-	if pod.Spec.NodeSelector == nil {
-		return nil
-	}
 	name, ok := pod.Spec.NodeSelector[v1alpha3.ProvisionerNameLabelKey]
-	if !ok {
+	if ok && name == provisioner.Name {
 		return nil
 	}
-	if name == provisioner.Name {
+	if !ok && v1alpha3.DefaultProvisioner.Name == provisioner.Name {
 		return nil
 	}
 	return fmt.Errorf("matched another provisioner, %s", name)

--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -89,10 +89,10 @@ func (f *Filter) hasSupportedSchedulingConstraints(pod *v1.Pod) error {
 
 func (f *Filter) matchesProvisioner(pod *v1.Pod, provisioner *v1alpha3.Provisioner) error {
 	name, ok := pod.Spec.NodeSelector[v1alpha3.ProvisionerNameLabelKey]
-	if ok && name == provisioner.Name {
+	if ok && provisioner.Name == name {
 		return nil
 	}
-	if !ok && v1alpha3.DefaultProvisioner.Name == provisioner.Name {
+	if !ok && provisioner.Name == v1alpha3.DefaultProvisioner.Name {
 		return nil
 	}
 	return fmt.Errorf("matched another provisioner, %s", name)

--- a/pkg/controllers/expiration/suite_test.go
+++ b/pkg/controllers/expiration/suite_test.go
@@ -15,10 +15,8 @@ limitations under the License.
 package expiration_test
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/Pallinder/go-randomdata"
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"github.com/awslabs/karpenter/pkg/controllers/expiration"
 	"github.com/awslabs/karpenter/pkg/test"
@@ -53,7 +51,7 @@ var _ = Describe("Reconciliation", func() {
 
 	BeforeEach(func() {
 		provisioner = &v1alpha3.Provisioner{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: v1alpha3.DefaultProvisioner.Name},
 			Spec: v1alpha3.ProvisionerSpec{
 				Cluster:                v1alpha3.Cluster{Name: ptr.String("test-cluster"), Endpoint: "http://test-cluster", CABundle: ptr.String("dGVzdC1jbHVzdGVyCg==")},
 				TTLSecondsUntilExpired: ptr.Int64(30),

--- a/pkg/controllers/reallocation/suite_test.go
+++ b/pkg/controllers/reallocation/suite_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Reallocation", func() {
 
 	BeforeEach(func() {
 		provisioner = &v1alpha3.Provisioner{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: v1alpha3.DefaultProvisioner.Name},
 			Spec: v1alpha3.ProvisionerSpec{
 				Cluster:              v1alpha3.Cluster{Name: ptr.String("test-cluster"), Endpoint: "http://test-cluster", CABundle: ptr.String("dGVzdC1jbHVzdGVyCg==")},
 				TTLSecondsAfterEmpty: ptr.Int64(300),


### PR DESCRIPTION
**Issue, if available:**
N/A

**Description of changes:**
 - Limits the number of times the error is logged when a provisioner is not found
 - Fixes a bug where if pods are pending when karpenter starts up, they will be reconciled to any provisioner (previous racing behavior). The matchesProvisioner func was not completely correct when checking the default provisioner. 
 - Moves the default provisioner to a reference in the apis pkg.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Previous Log:

```
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.188Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.200Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.568Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.568Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.571Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-86cf989bcd-jkqfm manager 2021-07-16T15:41:13.571Z	ERROR	Retrieving provisioner, create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
... 
... # number of pods + 1
```

New Log (50 pod scale-up w/ no provisioner - 2 times, one per pod batch + 1):

```
karpenter-controller-6769b9899b-cr99p manager 2021-07-16T18:18:56.455Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-cr99p manager 2021-07-16T18:18:59.455Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
```

New Log (1000 pod scale-up w/ no provisioner - prints 7 times, one per pod batch + 1):

```
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:13:35.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:13:45.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:13:56.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:14:07.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:14:17.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:14:22.541Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
karpenter-controller-6769b9899b-r66pp manager 2021-07-16T18:14:24.542Z	ERROR	No provisioner found. Create a default provisioner, or specify an alternative using the nodeSelector karpenter.sh/provisioner-name
```

## Why is it "per pod batch +1" you ask? 

The way the batch and work queue function. Karpenter watches for pod updates and adds the associated provisioner to the reconcile request work queue as they come in. So there will be a bunch of the same provisioner for a Deployment scale up. Reconcile will wait for a batch before starting, and then reconcile state for the cluster on the provisioner in the reconcile request. Since `Reconcile(..)` starts almost immediately (depending on the number of unique provisioners ahead in the queue and the configured reconcile workers which is 4 for karpenter currently), then a pod will be added to the work queue after reconcile has triggered. The work queue implementation won't know if the reconcile included the cluster state in the reconcile request, so it will dequeue one more after the batching ends, and since no provisioner requests are enqueued after that reconcile kicks off, no more will be dequeued. 
