### PR TITLE
Parallelizes capacity creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/aws/aws-sdk-go v1.38.69
+	github.com/deckarep/golang-set v1.7.1
 	github.com/go-logr/zapr v0.4.0
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-gk v0.0.0-20140819190930-201884a44051/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
 github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -35,9 +35,12 @@ import (
 )
 
 const (
-	// CreationQPS limits the number of
-	CreationQPS      = 5
-	CreationBurstQPS = 10
+	// CreationQPS limits the number of requests per second to CreateFleet
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html#throttling-limits
+	CreationQPS = 2
+	// CreationBurst limits the additional burst requests.
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html#throttling-limits
+	CreationBurst = 100
 	// CacheTTL restricts QPS to AWS APIs to this interval for verifying setup
 	// resources. This value represents the maximum eventual consistency between
 	// AWS actual state and the controller's ability to provision those
@@ -93,7 +96,7 @@ func NewCloudProvider(options cloudprovider.Options) *CloudProvider {
 		subnetProvider:       NewSubnetProvider(ec2api),
 		instanceTypeProvider: NewInstanceTypeProvider(ec2api),
 		instanceProvider:     &InstanceProvider{ec2api: ec2api},
-		creationQueue:       parallel.NewWorkQueue(CreationQPS, CreationBurstQPS),
+		creationQueue:        parallel.NewWorkQueue(CreationQPS, CreationBurst),
 	}
 }
 

--- a/pkg/cloudprovider/aws/docs/README.md
+++ b/pkg/cloudprovider/aws/docs/README.md
@@ -89,7 +89,7 @@ kubectl patch deployment karpenter-controller \
 ```
 
 ### Create a Provisioner
-Create a default Provisioner that launches nodes configured with cluster name, endpoint, and caBundle.
+Create a default Provisioner that launches nodes configured with cluster name and endpoint.
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: karpenter.sh/v1alpha3
@@ -99,7 +99,6 @@ metadata:
 spec:
   cluster:
     name: ${CLUSTER_NAME}
-    caBundle: $(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.certificateAuthority.data" --output json)
     endpoint: $(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json)
   ttlSecondsAfterEmpty: 30
 EOF

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -40,10 +40,10 @@ type EC2Behavior struct {
 	DescribeInstanceTypesOutput         *ec2.DescribeInstanceTypesOutput
 	DescribeInstanceTypeOfferingsOutput *ec2.DescribeInstanceTypeOfferingsOutput
 	DescribeAvailabilityZonesOutput     *ec2.DescribeAvailabilityZonesOutput
-	CalledWithCreateFleetInput          set.Set //[]*ec2.CreateFleetInput
-	CalledWithCreateLaunchTemplateInput set.Set // []*ec2.CreateLaunchTemplateInput
+	CalledWithCreateFleetInput          set.Set
+	CalledWithCreateLaunchTemplateInput set.Set
 	Instances                           sync.Map
-	LaunchTemplates                     sync.Map //[]*ec2.LaunchTemplate
+	LaunchTemplates                     sync.Map
 }
 
 type EC2API struct {
@@ -317,13 +317,3 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(ctx context.Conte
 	}, false)
 	return nil
 }
-
-// func (e *EC2API) ExpectCalledWithFleetLaunchTemplateOverridesRequest(overrides ...*ec2.FleetLaunchTemplateOverridesRequest) {
-// 	results := []*ec2.FleetLaunchTemplateOverridesRequest{}
-// 	e.calledWithCreateFleetInput.Range(func(key, value interface{}) bool {
-// 		for _, lt := range value.(*ec2.CreateFleetInput).LaunchTemplateConfigs {
-// 			results = append(results, lt.Overrides...)
-// 		}
-// 		return true
-// 	})
-// }

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -39,7 +39,7 @@ type EC2Behavior struct {
 	DescribeAvailabilityZonesOutput     *ec2.DescribeAvailabilityZonesOutput
 	CalledWithCreateFleetInput          []*ec2.CreateFleetInput
 	CalledWithCreateLaunchTemplateInput []*ec2.CreateLaunchTemplateInput
-	Instances                           []*ec2.Instance
+	CreatedInstance                     *ec2.Instance
 	LaunchTemplates                     []*ec2.LaunchTemplate
 }
 
@@ -63,10 +63,10 @@ func (e *EC2API) CreateFleetWithContext(ctx context.Context, input *ec2.CreateFl
 	instance := &ec2.Instance{
 		InstanceId:     aws.String(randomdata.SillyName()),
 		Placement:      &ec2.Placement{AvailabilityZone: aws.String("test-zone-1a")},
-		PrivateDnsName: aws.String(fmt.Sprintf("test-instance-%d.example.com", len(e.Instances))),
+		PrivateDnsName: aws.String(randomdata.IpV4Address()),
 		InstanceType:   input.LaunchTemplateConfigs[0].Overrides[0].InstanceType,
 	}
-	e.Instances = append(e.Instances, instance)
+	e.CreatedInstance = instance
 	return &ec2.CreateFleetOutput{Instances: []*ec2.CreateFleetInstance{{InstanceIds: []*string{instance.InstanceId}}}}, nil
 }
 
@@ -82,7 +82,7 @@ func (e *EC2API) DescribeInstancesWithContext(context.Context, *ec2.DescribeInst
 		return e.DescribeInstancesOutput, nil
 	}
 	return &ec2.DescribeInstancesOutput{
-		Reservations: []*ec2.Reservation{{Instances: e.Instances}},
+		Reservations: []*ec2.Reservation{{Instances: []*ec2.Instance{e.CreatedInstance}}},
 	}, nil
 }
 

--- a/pkg/cloudprovider/aws/node.go
+++ b/pkg/cloudprovider/aws/node.go
@@ -48,7 +48,7 @@ func (n *NodeFactory) For(ctx context.Context, instanceId *string) (*v1.Node, er
 	if len(describeInstancesOutput.Reservations[0].Instances) != 1 {
 		return nil, fmt.Errorf("expected a single instance, got %d", len(describeInstancesOutput.Reservations[0].Instances))
 	}
-	instance := describeInstancesOutput.Reservations[0].Instances[0]
+	instance := *describeInstancesOutput.Reservations[0].Instances[0]
 	zap.S().Infof("Launched instance: %s, type: %s, zone: %s, hostname: %s",
 		*instance.InstanceId,
 		*instance.InstanceType,

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -399,161 +399,161 @@ var _ = Describe("Allocation", func() {
 					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
 				))
 			})
-				It("should default to a provisioner's specified subnet name", func() {
-					// Setup
-					provisioner.Spec.Labels = map[string]string{SubnetNameLabel: "test-subnet-2"}
-					provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).To(HaveKeyWithValue(SubnetNameLabel, provisioner.Spec.Labels[SubnetNameLabel]))
-					Expect(node.Labels).ToNot(HaveKey(SubnetTagKeyLabel))
-					Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
-					Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
-					Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
-						&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large")},
-					))
-				})
-				It("should default to a provisioner's specified subnet tag key", func() {
-					provisioner.Spec.Labels = map[string]string{SubnetTagKeyLabel: "TestTag"}
-					provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SubnetNameLabel))
-					Expect(node.Labels).To(HaveKeyWithValue(SubnetTagKeyLabel, provisioner.Spec.Labels[SubnetTagKeyLabel]))
-					Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
-					Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
-					Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
-						&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
-					))
-				})
-				It("should allow a pod to override the subnet name", func() {
-					// Setup
-					provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
-						test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetNameLabel: "test-subnet-2"}}),
-					)
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SubnetTagKeyLabel))
-					Expect(node.Labels).To(HaveKeyWithValue(SubnetNameLabel, pods[0].Spec.NodeSelector[SubnetNameLabel]))
-					Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
-					Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
-					Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
-						&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large")},
-					))
-				})
-				It("should allow a pod to override the subnet tags", func() {
-					provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
-						test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetTagKeyLabel: "TestTag"}}),
-					)
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SubnetNameLabel))
-					Expect(node.Labels).To(HaveKeyWithValue(SubnetTagKeyLabel, pods[0].Spec.NodeSelector[SubnetTagKeyLabel]))
-					Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
-					Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
-					Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
-						&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
-					))
-				})
-				It("should not schedule a pod with an invalid subnet", func() {
-					provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningFailed(env.Client, controller, provisioner,
-						test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetTagKeyLabel: "Invalid"}}),
-					)
-					// Assertions
-					Expect(pods[0].Spec.NodeName).To(BeEmpty())
-				})
+			It("should default to a provisioner's specified subnet name", func() {
+				// Setup
+				provisioner.Spec.Labels = map[string]string{SubnetNameLabel: "test-subnet-2"}
+				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).To(HaveKeyWithValue(SubnetNameLabel, provisioner.Spec.Labels[SubnetNameLabel]))
+				Expect(node.Labels).ToNot(HaveKey(SubnetTagKeyLabel))
+				Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
+				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
+				Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large")},
+				))
 			})
-			Context("Security Groups", func() {
-				It("should default to the clusters security groups", func() {
-					// Setup
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
-					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
-					Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
-						aws.String("test-security-group-1"),
-						aws.String("test-security-group-2"),
-						aws.String("test-security-group-3"),
-					))
-				})
-				It("should default to a provisioner's specified security groups name", func() {
-					// Setup
-					provisioner.Spec.Labels = map[string]string{SecurityGroupNameLabel: "test-security-group-2"}
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupNameLabel, provisioner.Spec.Labels[SecurityGroupNameLabel]))
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
-					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
-					Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
-						aws.String("test-security-group-2"),
-					))
-				})
-				It("should default to a provisioner's specified security groups tag key", func() {
-					provisioner.Spec.Labels = map[string]string{SecurityGroupTagKeyLabel: "TestTag"}
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
-					Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupTagKeyLabel, provisioner.Spec.Labels[SecurityGroupTagKeyLabel]))
-					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
-					Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
-						aws.String("test-security-group-3"),
-					))
-				})
-				It("should allow a pod to override the security groups name", func() {
-					// Setup
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
-						test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SecurityGroupNameLabel: "test-security-group-2"}}),
-					)
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupNameLabel, pods[0].Spec.NodeSelector[SecurityGroupNameLabel]))
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
-					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
-					Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
-						aws.String("test-security-group-2"),
-					))
-				})
-				It("should allow a pod to override the security groups tags", func() {
-					ExpectCreated(env.Client, provisioner)
-					pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
-						test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SecurityGroupTagKeyLabel: "TestTag"}}),
-					)
-					// Assertions
-					node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
-					Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
-					Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupTagKeyLabel, pods[0].Spec.NodeSelector[SecurityGroupTagKeyLabel]))
-					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
-					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
-					Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
-						aws.String("test-security-group-3"),
-					))
-				})
+			It("should default to a provisioner's specified subnet tag key", func() {
+				provisioner.Spec.Labels = map[string]string{SubnetTagKeyLabel: "TestTag"}
+				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SubnetNameLabel))
+				Expect(node.Labels).To(HaveKeyWithValue(SubnetTagKeyLabel, provisioner.Spec.Labels[SubnetTagKeyLabel]))
+				Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
+				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
+				Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
+				))
+			})
+			It("should allow a pod to override the subnet name", func() {
+				// Setup
+				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
+					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetNameLabel: "test-subnet-2"}}),
+				)
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SubnetTagKeyLabel))
+				Expect(node.Labels).To(HaveKeyWithValue(SubnetNameLabel, pods[0].Spec.NodeSelector[SubnetNameLabel]))
+				Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
+				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
+				Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large")},
+				))
+			})
+			It("should allow a pod to override the subnet tags", func() {
+				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
+					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetTagKeyLabel: "TestTag"}}),
+				)
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SubnetNameLabel))
+				Expect(node.Labels).To(HaveKeyWithValue(SubnetTagKeyLabel, pods[0].Spec.NodeSelector[SubnetTagKeyLabel]))
+				Expect(fakeEC2API.CalledWithCreateFleetInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
+				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
+				Expect(input.LaunchTemplateConfigs[0].Overrides).To(ConsistOf(
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
+				))
+			})
+			It("should not schedule a pod with an invalid subnet", func() {
+				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningFailed(env.Client, controller, provisioner,
+					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetTagKeyLabel: "Invalid"}}),
+				)
+				// Assertions
+				Expect(pods[0].Spec.NodeName).To(BeEmpty())
+			})
+		})
+		Context("Security Groups", func() {
+			It("should default to the clusters security groups", func() {
+				// Setup
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
+				Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
+					aws.String("test-security-group-1"),
+					aws.String("test-security-group-2"),
+					aws.String("test-security-group-3"),
+				))
+			})
+			It("should default to a provisioner's specified security groups name", func() {
+				// Setup
+				provisioner.Spec.Labels = map[string]string{SecurityGroupNameLabel: "test-security-group-2"}
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupNameLabel, provisioner.Spec.Labels[SecurityGroupNameLabel]))
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
+				Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
+					aws.String("test-security-group-2"),
+				))
+			})
+			It("should default to a provisioner's specified security groups tag key", func() {
+				provisioner.Spec.Labels = map[string]string{SecurityGroupTagKeyLabel: "TestTag"}
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner, test.PendingPod())
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
+				Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupTagKeyLabel, provisioner.Spec.Labels[SecurityGroupTagKeyLabel]))
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
+				Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
+					aws.String("test-security-group-3"),
+				))
+			})
+			It("should allow a pod to override the security groups name", func() {
+				// Setup
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
+					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SecurityGroupNameLabel: "test-security-group-2"}}),
+				)
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupNameLabel, pods[0].Spec.NodeSelector[SecurityGroupNameLabel]))
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupTagKeyLabel))
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
+				Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
+					aws.String("test-security-group-2"),
+				))
+			})
+			It("should allow a pod to override the security groups tags", func() {
+				ExpectCreated(env.Client, provisioner)
+				pods := ExpectProvisioningSucceeded(env.Client, controller, provisioner,
+					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SecurityGroupTagKeyLabel: "TestTag"}}),
+				)
+				// Assertions
+				node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)
+				Expect(node.Labels).ToNot(HaveKey(SecurityGroupNameLabel))
+				Expect(node.Labels).To(HaveKeyWithValue(SecurityGroupTagKeyLabel, pods[0].Spec.NodeSelector[SecurityGroupTagKeyLabel]))
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
+				Expect(input.LaunchTemplateData.SecurityGroupIds).To(ConsistOf(
+					aws.String("test-security-group-3"),
+				))
+			})
 			It("should not schedule a pod with an invalid security group", func() {
 				ExpectCreated(env.Client, provisioner)
 				pods := ExpectProvisioningFailed(env.Client, controller, provisioner,

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/packing"
 	"github.com/awslabs/karpenter/pkg/test"
 	. "github.com/awslabs/karpenter/pkg/test/expectations"
+	"github.com/awslabs/karpenter/pkg/utils/parallel"
 	"github.com/awslabs/karpenter/pkg/utils/resources"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -66,6 +67,7 @@ var env = test.NewEnvironment(func(e *test.Environment) {
 		subnetProvider:       NewSubnetProvider(fakeEC2API),
 		instanceTypeProvider: NewInstanceTypeProvider(fakeEC2API),
 		instanceProvider:     &InstanceProvider{fakeEC2API},
+		creationQueue:        parallel.NewWorkQueue(CreationQPS, CreationBurstQPS),
 	}
 	registry.RegisterOrDie(cloudProvider)
 	controller = &allocation.Controller{

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -67,7 +67,7 @@ var env = test.NewEnvironment(func(e *test.Environment) {
 		subnetProvider:       NewSubnetProvider(fakeEC2API),
 		instanceTypeProvider: NewInstanceTypeProvider(fakeEC2API),
 		instanceProvider:     &InstanceProvider{fakeEC2API},
-		creationQueue:        parallel.NewWorkQueue(CreationQPS, CreationBurstQPS),
+		creationQueue:        parallel.NewWorkQueue(CreationQPS, CreationBurst),
 	}
 	registry.RegisterOrDie(cloudProvider)
 	controller = &allocation.Controller{

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -32,7 +32,7 @@ import (
 
 type CloudProvider struct{}
 
-func (c *CloudProvider) Create(ctx context.Context, provisioner *v1alpha3.Provisioner, packing *cloudprovider.Packing) (*v1.Node, error) {
+func (c *CloudProvider) Create(ctx context.Context, provisioner *v1alpha3.Provisioner, packing *cloudprovider.Packing, bind func(*v1.Node) error) chan error {
 	name := strings.ToLower(randomdata.SillyName())
 	// Pick first instance type option
 	instance := packing.InstanceTypeOptions[0]
@@ -43,28 +43,31 @@ func (c *CloudProvider) Create(ctx context.Context, provisioner *v1alpha3.Provis
 	}
 	zone := zones[0]
 
-	// Create instance
-	return &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: packing.Constraints.Labels,
-		},
-		Spec: v1.NodeSpec{
-			ProviderID: fmt.Sprintf("fake:///%s/%s", name, zone),
-			Taints:     packing.Constraints.Taints,
-		},
-		Status: v1.NodeStatus{
-			NodeInfo: v1.NodeSystemInfo{
-				Architecture:    instance.Architectures()[0],
-				OperatingSystem: instance.OperatingSystems()[0],
+	err := make(chan error)
+	go func () {
+		err <- bind(&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: packing.Constraints.Labels,
 			},
-			Allocatable: v1.ResourceList{
-				v1.ResourcePods:   *instance.Pods(),
-				v1.ResourceCPU:    *instance.CPU(),
-				v1.ResourceMemory: *instance.Memory(),
+			Spec: v1.NodeSpec{
+				ProviderID: fmt.Sprintf("fake:///%s/%s", name, zone),
+				Taints:     packing.Constraints.Taints,
 			},
-		},
-	}, nil
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{
+					Architecture:    instance.Architectures()[0],
+					OperatingSystem: instance.OperatingSystems()[0],
+				},
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods:   *instance.Pods(),
+					v1.ResourceCPU:    *instance.CPU(),
+					v1.ResourceMemory: *instance.Memory(),
+				},
+			},
+		})
+	}()
+	return err
 }
 
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context) ([]cloudprovider.InstanceType, error) {

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -33,7 +33,6 @@ import (
 type CloudProvider struct{}
 
 func (c *CloudProvider) Create(ctx context.Context, provisioner *v1alpha3.Provisioner, packing *cloudprovider.Packing) (*v1.Node, error) {
-	// packedNodes := []*cloudprovider.PackedNode{}
 	name := strings.ToLower(randomdata.SillyName())
 	// Pick first instance type option
 	instance := packing.InstanceTypeOptions[0]

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -24,10 +24,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// CloudProvider holds contains the methods necessary in a cloud provider
+// CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {
-	// Create a set of nodes for each of the given constraints.
-	Create(context.Context, *v1alpha3.Provisioner, *Packing) (*v1.Node, error)
+	// Create a set of nodes for each of the given constraints. This API uses a
+	// callback pattern to enable cloudproviders to batch capacity creation
+	// requests. The callback must be called with a theoretical node object that
+	// is fulfilled by the cloud providers capacity creation request. This API
+	// is called in parallel and then waits for all channels to return nil or error.
+	Create(context.Context, *v1alpha3.Provisioner, *Packing, func(*v1.Node) error) chan error
 	// GetInstanceTypes returns the instance types supported by the cloud
 	// provider limited by the provided constraints and daemons.
 	GetInstanceTypes(context.Context) ([]InstanceType, error)

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -27,7 +27,7 @@ import (
 // CloudProvider holds contains the methods necessary in a cloud provider
 type CloudProvider interface {
 	// Create a set of nodes for each of the given constraints.
-	Create(context.Context, *v1alpha3.Provisioner, []*Packing) ([]*PackedNode, error)
+	Create(context.Context, *v1alpha3.Provisioner, *Packing) (*v1.Node, error)
 	// GetInstanceTypes returns the instance types supported by the cloud
 	// provider limited by the provided constraints and daemons.
 	GetInstanceTypes(context.Context) ([]InstanceType, error)

--- a/pkg/controllers/allocation/bind.go
+++ b/pkg/controllers/allocation/bind.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,7 @@ func (b *Binder) Bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) error 
 	}
 
 	// 4. Bind pods
+	zap.S().Infof("Binding %d pod(s) to node %s", len(pods), node.Name)
 	errs := make([]error, len(pods))
 	workqueue.ParallelizeUntil(ctx, len(pods), len(pods), func(index int) {
 		errs[index] = b.bind(ctx, node, pods[index])

--- a/pkg/controllers/allocation/bind.go
+++ b/pkg/controllers/allocation/bind.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
-	"go.uber.org/zap"
+	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -59,12 +60,11 @@ func (b *Binder) Bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) error 
 	}
 
 	// 4. Bind pods
-	for _, pod := range pods {
-		if err := b.bind(ctx, node, pod); err != nil {
-			zap.S().Errorf("Continuing after failing to bind, %s", err.Error())
-		}
-	}
-	return nil
+	errs := make([]error, len(pods))
+	workqueue.ParallelizeUntil(ctx, len(pods), len(pods), func(index int) {
+		errs[index] = b.bind(ctx, node, pods[index])
+	})
+	return multierr.Combine(errs...)
 }
 
 func (b *Binder) bind(ctx context.Context, node *v1.Node, pod *v1.Pod) error {

--- a/pkg/controllers/expiration/controller.go
+++ b/pkg/controllers/expiration/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	expirationTTL := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsUntilExpired)) * time.Second
 	expirationTime := node.CreationTimestamp.Add(expirationTTL)
 	if time.Now().After(expirationTime) {
-		zap.S().Infof("Triggering termination after %s (+%s) for expired node %s", expirationTTL, time.Since(expirationTime), node.Name)
+		zap.S().Infof("Triggering termination for expired node %s after %s (+%s)", node.Name, expirationTTL, time.Since(expirationTime))
 		if err := c.kubeClient.Delete(ctx, node); err != nil {
 			return reconcile.Result{}, fmt.Errorf("expiring node %s, %w", node.Name, err)
 		}

--- a/pkg/controllers/reallocation/utilization.go
+++ b/pkg/controllers/reallocation/utilization.go
@@ -68,7 +68,7 @@ func (u *Utilization) markUnderutilized(ctx context.Context, provisioner *v1alph
 		if err := u.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
 			return fmt.Errorf("patching node %s, %w", node.Name, err)
 		}
-		zap.S().Debugf("Added TTL and label to underutilized node %s", node.Name)
+		zap.S().Infof("Added TTL and label to underutilized node %s", node.Name)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (u *Utilization) clearUnderutilized(ctx context.Context, provisioner *v1alp
 			if err := u.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
 				return fmt.Errorf("removing underutilized label on %s, %w", node.Name, err)
 			} else {
-				zap.S().Debugf("Removed TTL from node %s", node.Name)
+				zap.S().Infof("Removed TTL from node %s", node.Name)
 			}
 		}
 	}

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -50,7 +50,7 @@ func (t *Terminator) cordon(ctx context.Context, node *v1.Node) error {
 	if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil {
 		return fmt.Errorf("patching node %s, %w", node.Name, err)
 	}
-	zap.S().Debugf("Cordoned node %s", node.Name)
+	zap.S().Infof("Cordoned node %s", node.Name)
 	return nil
 }
 

--- a/pkg/packing/packer.go
+++ b/pkg/packing/packer.go
@@ -78,7 +78,7 @@ func (p *packer) Pack(ctx context.Context, constraints *Constraints, instances [
 			continue
 		}
 		packings = append(packings, packing)
-		zap.S().Debugf("Computed packing for pod(s) %v with instance type option(s) %s", apiobject.PodNamespacedNames(packing.Pods), instanceTypeNames(packing.InstanceTypeOptions))
+		zap.S().Infof("Computed packing for %d pod(s) with instance type option(s) %s", len(packing.Pods), instanceTypeNames(packing.InstanceTypeOptions))
 	}
 	return packings
 }

--- a/pkg/utils/parallel/workqueue.go
+++ b/pkg/utils/parallel/workqueue.go
@@ -1,0 +1,51 @@
+package parallel
+
+import (
+	"sync"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type WorkQueue struct {
+	workqueue.RateLimitingInterface
+	once    sync.Once
+}
+
+func NewWorkQueue(qps int, burst int) *WorkQueue {
+	return &WorkQueue{
+		RateLimitingInterface: workqueue.NewRateLimitingQueue(&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(qps), burst)}),
+	}
+}
+
+type Task struct {
+	do   func() error
+	done chan error
+	err  error
+}
+
+// Add work to the queue, returns a channel that signals when the work is done.
+func (c *WorkQueue) Add(do func() error) chan error {
+	c.once.Do(c.start)
+	done := make(chan error)
+	c.AddRateLimited(&Task{do: do, done: done})
+	return done
+}
+
+func (c *WorkQueue) start() {
+	go func() {
+		for {
+			item, shutdown := c.Get()
+			if shutdown {
+				break
+			}
+			task := item.(*Task)
+			go func() {
+				task.err = task.do()
+				c.Forget(task)
+				c.Done(task)
+				task.done <- task.err
+			}()
+		}
+	}()
+}


### PR DESCRIPTION
**Description of changes:**
Previously, the capacity API took multiple instances to allow cloud providers to batch create/get/delete API calls. However, this had a linearizing side effect such that all instances must be launched before karpenter was able to bind pods. This resulted in increased cases where the scheduler would schedule to capacity (launch by the linear loop) before Karpenter could execute the binds. Parallelizing also has the obvious side effect of making things launch a lot faster (unmeasured).

There are some long term considerations to this change:
1. Cloud providers will no longer (easily) be able to batch capacity API calls
2. Cloud providers will no longer be able to see multiple packings at once, which could allow for re-packing.

The primary benefits are:
1. The Capacity API is now simpler and more natural. 
2. Launching capacity for constraint groups is now parallelized in vendor neutral code.
3. A slow cloud provider implementation can no longer hang on linear capacity creation.
3. More code (node object construction, parallelization) is moved out of the AWS Cloud Provider and into Karpenter's core.

Additionally, I swapped the verbosity of a few log statements.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
