### PR TITLE
Build and Host Website on Netlify

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,10 +1,8 @@
-baseURL = "karpenter/"
-
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]
 
 # Build settings
-publishDir = "../docs"
+baseURL = "/"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Language settings

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,0 +1,31 @@
+[build]
+base = "website/"
+publish = "public"
+command = "npm install; git submodule update --init --recursive; hugo --gc --minify"
+
+[context.production.environment]
+HUGO_VERSION = "0.86.0"
+HUGO_ENV = "production"
+HUGO_ENABLEGITINFO = "true"
+
+[context.split1]
+command = "npm install; git submodule update --init --recursive; hugo --gc --minify --enableGitInfo"
+
+[context.split1.environment]
+HUGO_VERSION = "0.86.0"
+HUGO_ENV = "production"
+
+[context.deploy-preview]
+command = "npm install; git submodule update --init --recursive; hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+
+[context.deploy-preview.environment]
+HUGO_VERSION = "0.86.0"
+
+[context.branch-deploy]
+command = "npm install; git submodule update --init --recursive; hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+HUGO_VERSION = "0.86.0"
+
+[context.next.environment]
+HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
**Issue, if available:**
N/A

**Description of changes:**
After wrestling with Github Pages for the last 24 hours, and failing to get it to play nicely with Karpenter's monorepo structure and Hugo, I propose we build and host the docs site on [Netlify](https://www.netlify.com/). Over time we can evolve this approach as needed, but for the near term, I believe this is good solution for the project.

This PR includes two changes, first is a `netlify.toml` config file that is essentially copied from the [Hugo Netlify docs](https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify). The second change is a minor change to the Hugo configuration file to simplify the `baseURL` and remove the `publishDir` as its no longer needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
