### PR TITLE
add Name tag to default launch template

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -160,6 +160,10 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 				ResourceType: aws.String(ec2.ResourceTypeInstance),
 				Tags: []*ec2.Tag{
 					{
+						Key:   aws.String("Name"),
+						Value: aws.String(fmt.Sprintf("Karpenter/%s", ptr.StringValue(options.Cluster.Name))),
+					},
+					{
 						Key:   aws.String(fmt.Sprintf(ClusterTagKeyFormat, ptr.StringValue(options.Cluster.Name))),
 						Value: aws.String("owned"),
 					},


### PR DESCRIPTION
**Issue, if available:**
N/A

**Description of changes:**
 - Adds a Name tag to the default Karpenter Launch Template (this is the launch template hardcoded in Karpenter that is used when a user does not override the launch template).  The Name tag in EC2 is a special tag that is used to fill the Name column of the EC2 Web Console. 
 - If a user overrides the launch template, they can specify any Name tag they'd like on the EC2 instance Karpenter will create.

The name format is `Karpenter/<Cluster-Name>` I can't add the K8s Node Name since the name doesn't exist until after an instance is launched. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
