### PR TITLE
Readjusted reallocation controller for nodes that fail to come up

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -83,7 +83,7 @@ func main() {
 	if err := manager.RegisterControllers(ctx,
 		expiration.NewController(manager.GetClient()),
 		allocation.NewController(manager.GetClient(), clientSet.CoreV1(), cloudProvider),
-		reallocation.NewController(manager.GetClient(), clientSet.CoreV1(), cloudProvider),
+		reallocation.NewController(manager.GetClient(), cloudProvider),
 		termination.NewController(ctx, manager.GetClient(), clientSet.CoreV1(), cloudProvider),
 	).Start(ctx); err != nil {
 		panic(fmt.Sprintf("Unable to start manager, %s", err.Error()))

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/awslabs/karpenter
 go 1.16
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v2.7.0+incompatible
 	github.com/aws/aws-sdk-go v1.38.69
-	github.com/benbjohnson/clock v1.1.0
 	github.com/deckarep/golang-set v1.7.1
 	github.com/go-logr/zapr v0.4.0
 	github.com/imdario/mergo v0.3.12
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	go.uber.org/multierr v1.7.0
-	go.uber.org/zap v1.18.1
+	go.uber.org/zap v1.18.1 // indirect
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	k8s.io/api v0.20.7
 	k8s.io/apimachinery v0.20.7

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v2.7.0+incompatible
 	github.com/aws/aws-sdk-go v1.38.69
+	github.com/benbjohnson/clock v1.1.0
 	github.com/deckarep/golang-set v1.7.1
 	github.com/go-logr/zapr v0.4.0
 	github.com/imdario/mergo v0.3.12

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/controllers/reallocation/controller.go
+++ b/pkg/controllers/reallocation/controller.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/time/rate"
 	"knative.dev/pkg/logging"
 
+	"github.com/benbjohnson/clock"
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -36,17 +37,17 @@ import (
 
 // Controller for the resource
 type Controller struct {
-	utilization   *Utilization
-	cloudProvider cloudprovider.CloudProvider
-	kubeClient    client.Client
+	Utilization   *Utilization
+	CloudProvider cloudprovider.CloudProvider
+	KubeClient    client.Client
 }
 
 // NewController constructs a controller instance
 func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider) *Controller {
 	return &Controller{
-		utilization:   &Utilization{kubeClient: kubeClient},
-		cloudProvider: cloudProvider,
-		kubeClient:    kubeClient,
+		Utilization:   &Utilization{KubeClient: kubeClient, Clock: clock.New()},
+		CloudProvider: cloudProvider,
+		KubeClient:    kubeClient,
 	}
 }
 
@@ -56,7 +57,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// 1. Retrieve provisioner from reconcile request
 	provisioner := &v1alpha3.Provisioner{}
-	if err := c.kubeClient.Get(ctx, req.NamespacedName, provisioner); err != nil {
+	if err := c.KubeClient.Get(ctx, req.NamespacedName, provisioner); err != nil {
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
@@ -64,7 +65,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// 2. Delete any node that has been unable to come up for 5 minutes.
-	if err := c.utilization.terminateFailedToJoin(ctx, provisioner); err != nil {
+	if err := c.Utilization.terminateFailedToJoin(ctx, provisioner); err != nil {
 		return reconcile.Result{}, fmt.Errorf("terminating nodes that failed to join, %w", err)
 	}
 
@@ -72,18 +73,19 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if provisioner.Spec.TTLSecondsAfterEmpty == nil {
 		return reconcile.Result{}, nil
 	}
+
 	// 3. Set TTL on TTLable Nodes
-	if err := c.utilization.markUnderutilized(ctx, provisioner); err != nil {
+	if err := c.Utilization.markUnderutilized(ctx, provisioner); err != nil {
 		return reconcile.Result{}, fmt.Errorf("adding ttl and underutilized label, %w", err)
 	}
 
 	// 4. Remove TTL from Utilized Nodes
-	if err := c.utilization.clearUnderutilized(ctx, provisioner); err != nil {
+	if err := c.Utilization.clearUnderutilized(ctx, provisioner); err != nil {
 		return reconcile.Result{}, fmt.Errorf("removing ttl from node, %w", err)
 	}
 
 	// 5. Delete any node past its TTL
-	if err := c.utilization.terminateExpired(ctx, provisioner); err != nil {
+	if err := c.Utilization.terminateExpired(ctx, provisioner); err != nil {
 		return reconcile.Result{}, fmt.Errorf("marking nodes terminable, %w", err)
 	}
 

--- a/pkg/controllers/reallocation/controller.go
+++ b/pkg/controllers/reallocation/controller.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"k8s.io/apimachinery/pkg/api/errors"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +42,7 @@ type Controller struct {
 }
 
 // NewController constructs a controller instance
-func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider) *Controller {
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
 	return &Controller{
 		Utilization:   &Utilization{KubeClient: kubeClient, Clock: clock.New()},
 		CloudProvider: cloudProvider,

--- a/pkg/controllers/reallocation/controller.go
+++ b/pkg/controllers/reallocation/controller.go
@@ -64,8 +64,8 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// 2. Delete any node that has been unable to come up for 5 minutes.
-	if err := c.utilization.terminateFailedToBecomeReady(ctx, provisioner); err != nil {
-		return reconcile.Result{}, fmt.Errorf("terminating nodes that failed to become ready, %w", err)
+	if err := c.utilization.terminateFailedToJoin(ctx, provisioner); err != nil {
+		return reconcile.Result{}, fmt.Errorf("terminating nodes that failed to join, %w", err)
 	}
 
 	// Skip reconciliation if utilization ttl is not defined.

--- a/pkg/controllers/reallocation/controller.go
+++ b/pkg/controllers/reallocation/controller.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/time/rate"
 	"knative.dev/pkg/logging"
 
-	"github.com/benbjohnson/clock"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -44,7 +43,7 @@ type Controller struct {
 // NewController constructs a controller instance
 func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
 	return &Controller{
-		Utilization:   &Utilization{KubeClient: kubeClient, Clock: clock.New()},
+		Utilization:   &Utilization{KubeClient: kubeClient},
 		CloudProvider: cloudProvider,
 		KubeClient:    kubeClient,
 	}
@@ -63,7 +62,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// 2. Delete any node that has been unable to come up for 5 minutes.
+	// 2. Delete any node that has been unable to join.
 	if err := c.Utilization.terminateFailedToJoin(ctx, provisioner); err != nil {
 		return reconcile.Result{}, fmt.Errorf("terminating nodes that failed to join, %w", err)
 	}

--- a/pkg/controllers/reallocation/suite_test.go
+++ b/pkg/controllers/reallocation/suite_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Reallocation", func() {
 			Expect(updatedNode.Labels).ToNot(HaveKey(v1alpha3.ProvisionerUnderutilizedLabelKey))
 			Expect(updatedNode.Annotations).ToNot(HaveKey(v1alpha3.ProvisionerTTLAfterEmptyKey))
 		})
-		It("should not TTL nodes that have ready status unknown", func() {
+		It("should not TTL nodes that have ready status false", func() {
 			node := test.Node(test.NodeOptions{
 				ReadyStatus: v1.ConditionFalse,
 			})

--- a/pkg/controllers/reallocation/suite_test.go
+++ b/pkg/controllers/reallocation/suite_test.go
@@ -82,6 +82,34 @@ var _ = Describe("Reallocation", func() {
 	})
 
 	Context("Reconciliation", func() {
+		It("should not TTL nodes that have ready status unknown", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionUnknown,
+			})
+
+			ExpectCreated(env.Client, provisioner)
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(controller, client.ObjectKeyFromObject(provisioner))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Labels).ToNot(HaveKey(v1alpha3.ProvisionerUnderutilizedLabelKey))
+			Expect(updatedNode.Annotations).ToNot(HaveKey(v1alpha3.ProvisionerTTLAfterEmptyKey))
+		})
+		It("should not TTL nodes that have ready status unknown", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionFalse,
+			})
+
+			ExpectCreated(env.Client, provisioner)
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(controller, client.ObjectKeyFromObject(provisioner))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Labels).ToNot(HaveKey(v1alpha3.ProvisionerUnderutilizedLabelKey))
+			Expect(updatedNode.Annotations).ToNot(HaveKey(v1alpha3.ProvisionerTTLAfterEmptyKey))
+		})
 		It("should label nodes as underutilized and add TTL", func() {
 			node := test.Node(test.NodeOptions{
 				Labels: map[string]string{

--- a/pkg/controllers/reallocation/utilization.go
+++ b/pkg/controllers/reallocation/utilization.go
@@ -123,7 +123,7 @@ func (u *Utilization) terminateExpired(ctx context.Context, provisioner *v1alpha
 	return nil
 }
 
-func (u *Utilization) terminateFailedToBecomeReady(ctx context.Context, provisioner *v1alpha3.Provisioner) error {
+func (u *Utilization) terminateFailedToJoin(ctx context.Context, provisioner *v1alpha3.Provisioner) error {
 	// 1. Get nodes
 	nodes, err := u.getNodes(ctx, provisioner, map[string]string{})
 	if err != nil {

--- a/pkg/controllers/reallocation/utilization.go
+++ b/pkg/controllers/reallocation/utilization.go
@@ -119,7 +119,7 @@ func (u *Utilization) terminateExpired(ctx context.Context, provisioner *v1alpha
 	for _, node := range nodes {
 		if utilsnode.IsPastEmptyTTL(node) {
 			logging.FromContext(ctx).Infof("Triggering termination for empty node %s", node.Name)
-			if err := u.kubeClient.Delete(ctx, node); err != nil {
+			if err := u.KubeClient.Delete(ctx, node); err != nil {
 				return fmt.Errorf("sending delete for node %s, %w", node.Name, err)
 			}
 		}

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -40,6 +40,7 @@ var ctx context.Context
 var controller *termination.Controller
 var evictionQueue *termination.EvictionQueue
 var env *test.Environment
+
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -79,7 +79,9 @@ func ExpectDeleted(c client.Client, objects ...client.Object) {
 		persisted := object.DeepCopyObject()
 		object.SetFinalizers([]string{})
 		Expect(c.Patch(context.Background(), object, client.MergeFrom(persisted))).To(Succeed())
-		Expect(c.Delete(context.Background(), object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)})).To(Succeed())
+		if err := c.Delete(context.Background(), object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}); !errors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
 	}
 	for _, object := range objects {
 		ExpectNotFound(c, object)

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -39,6 +39,7 @@ type PodOptions struct {
 	Conditions           []v1.PodCondition
 	Annotations          map[string]string
 	Labels               map[string]string
+	Finalizers           []string
 }
 
 type PDBOptions struct {
@@ -74,6 +75,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 			OwnerReferences: options.OwnerReferences,
 			Annotations:     options.Annotations,
 			Labels:          options.Labels,
+			Finalizers:      options.Finalizers,
 		},
 		Spec: v1.PodSpec{
 			NodeSelector: options.NodeSelector,

--- a/pkg/utils/node/predicates.go
+++ b/pkg/utils/node/predicates.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/benbjohnson/clock"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -29,8 +30,8 @@ func IsReady(node *v1.Node) bool {
 	return getNodeCondition(node.Status.Conditions, v1.NodeReady).Status == v1.ConditionTrue
 }
 
-func FailedToJoin(node *v1.Node, duration time.Duration) bool {
-	if time.Since(node.GetCreationTimestamp().Time) < duration {
+func FailedToJoin(node *v1.Node, c clock.Clock, duration time.Duration) bool {
+	if c.Since(node.GetCreationTimestamp().Time) < duration {
 		return false
 	}
 	condition := getNodeCondition(node.Status.Conditions, v1.NodeReady)

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -45,6 +45,16 @@ func IsSchedulable(pod *v1.PodSpec, node *v1.Node) bool {
 	return true
 }
 
+// ContainsUnignoredPods returns true if the set of pods has a non-daemonset pod
+func ContainsUnignoredPods(pods []*v1.Pod) bool {
+	for _, p := range pods {
+		if HasFailed(p) || !IsOwnedByDaemonSet(p) {
+			return true
+		}
+	}
+	return false
+}
+
 // ToleratesTaints returns an error if the pod does not tolerate the taints
 // https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
 func ToleratesTaints(spec *v1.PodSpec, taints ...v1.Taint) (err error) {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -58,6 +58,16 @@ func IgnoredForUnderutilization(pods []*v1.Pod) bool {
 	return true
 }
 
+// AreAllTerminating returns true if the set of pods were all unable to join
+func AreAllTerminating(pods []*v1.Pod) bool {
+	for _, p := range pods {
+		if p.DeletionTimestamp.IsZero() && !IsOwnedByDaemonSet(p) {
+			return false
+		}
+	}
+	return true
+}
+
 // ToleratesTaints returns an error if the pod does not tolerate the taints
 // https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
 func ToleratesTaints(spec *v1.PodSpec, taints ...v1.Taint) (err error) {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -45,14 +45,17 @@ func IsSchedulable(pod *v1.PodSpec, node *v1.Node) bool {
 	return true
 }
 
-// ContainsUnignoredPods returns true if the set of pods has a non-daemonset pod
-func ContainsUnignoredPods(pods []*v1.Pod) bool {
+// IgnoredForUnderutilization returns true if the set of pods has no non-daemonset pods
+func IgnoredForUnderutilization(pods []*v1.Pod) bool {
 	for _, p := range pods {
-		if HasFailed(p) || !IsOwnedByDaemonSet(p) {
-			return true
+		if HasFailed(p) {
+			continue
+		}
+		if !IsOwnedByDaemonSet(p) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // ToleratesTaints returns an error if the pod does not tolerate the taints

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -58,16 +58,6 @@ func IgnoredForUnderutilization(pods []*v1.Pod) bool {
 	return true
 }
 
-// AreAllTerminating returns true if the set of pods were all unable to join
-func AreAllTerminating(pods []*v1.Pod) bool {
-	for _, p := range pods {
-		if p.DeletionTimestamp.IsZero() && !IsOwnedByDaemonSet(p) {
-			return false
-		}
-	}
-	return true
-}
-
 // ToleratesTaints returns an error if the pod does not tolerate the taints
 // https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
 func ToleratesTaints(spec *v1.PodSpec, taints ...v1.Taint) (err error) {


### PR DESCRIPTION
**Description of changes:**
This PR changes how reallocation controls the underutilization of nodes depending on their status. 

Previously we used to set nodes as underutilized and set a TTL (as specified in the Provisioner) for nodes, regardless of their status. This results in a race condition where nodes are brought up, and we could set a TTL before pods bind to them. This change now only allows us to do so for Ready nodes. 

In addition, this PR adds the feature to delete nodes that fail to become ready after 15 minutes, designed [here](https://github.com/awslabs/karpenter/blob/main/designs/termination.md#karpenter-availability-and-termination-cases). Since there are many reasons why nodes could become NotReady after becoming ready, we only consider nodes that were unable to come up, but not nodes that were able to come up but had connectivity issues, like KubeletNotReady. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
