### PR TITLE
fix link to eks-config.yaml

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -57,7 +57,7 @@ KARPENTER_VERSION=$(curl -fsSL \
 Create a cluster with `eksctl`. The [example configuration](eks-config.yaml) file specifies a basic cluster (name, region), and an IAM role for Karpenter to use. 
 
 ```bash
-curl -fsSL  https://raw.githubusercontent.com/awslabs/karpenter/"${KARPENTER_VERSION}"/pkg/cloudprovider/aws/docs/eks-config.yaml \
+curl -fsSL  https://www.karpenter.sh/docs/getting-started/eks-config.yaml \
   | envsubst \
   | eksctl create cluster -f -
 ```


### PR DESCRIPTION
change link to non-fargate version, also use shorter link

**Issue, if available:**
#538 

**Description of changes:**

changes the link to eks-config.yaml to the proper non-fargate version 

```bash
curl -fsSL  https://www.karpenter.sh/docs/getting-started/eks-config.yaml
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
