### PR TITLE
Resolved docs 404 error and updated FAQ to new doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Follow the setup recommendations of your cloud provider.
 > - Reinstall Karpenter
 
 ## References
-- [Docs](https://awslabs.github.io/karpenter/docs)
+- [Docs](https://karpenter.sh/docs/)
 - [API](README.md)
-- [FAQs](FAQs.md)
+- [FAQs](https://karpenter.sh/docs/faqs/)
 - [Roadmap](ROADMAP.md)
 - [Working Group](WORKING_GROUP.md)
 - [Developer Guide](DEVELOPER_GUIDE.md)


### PR DESCRIPTION
**Issue, if available:**


**Description of changes:**
I updated the Docs and FAQ links in the README to point to the new documentation site. The current Docs link generates 404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
