### PR TITLE
Improve error logging from multiple packing errors

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -476,7 +476,7 @@ var _ = Describe("Allocation", func() {
 			It("should not schedule a pod with an invalid subnet", func() {
 				provisioner.Spec.InstanceTypes = []string{"m5.large"} // limit instance type to simplify ConsistOf checks
 				ExpectCreated(env.Client, provisioner)
-				pods := ExpectProvisioningFailed(ctx, env.Client, controller, provisioner,
+				pods := ExpectProvisioningSucceeded(ctx, env.Client, controller, provisioner,
 					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SubnetTagKeyLabel: "Invalid"}}),
 				)
 				// Assertions
@@ -562,7 +562,7 @@ var _ = Describe("Allocation", func() {
 			})
 			It("should not schedule a pod with an invalid security group", func() {
 				ExpectCreated(env.Client, provisioner)
-				pods := ExpectProvisioningFailed(ctx, env.Client, controller, provisioner,
+				pods := ExpectProvisioningSucceeded(ctx, env.Client, controller, provisioner,
 					test.PendingPod(test.PodOptions{NodeSelector: map[string]string{SecurityGroupTagKeyLabel: "Invalid"}}),
 				)
 				// Assertions

--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -54,6 +54,7 @@ func (f *Filter) GetProvisionablePods(ctx context.Context, provisioner *v1alpha3
 		}
 		provisionable = append(provisionable, ptr.Pod(p))
 	}
+	logging.FromContext(ctx).Infof("Found %d provisionable pods", len(provisionable))
 	return provisionable, nil
 }
 

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -122,23 +122,6 @@ func ExpectProvisioningSucceeded(ctx context.Context, c client.Client, reconcile
 	return result
 }
 
-func ExpectProvisioningFailed(ctx context.Context, c client.Client, reconciler reconcile.Reconciler, provisioner *v1alpha3.Provisioner, pods ...*v1.Pod) []*v1.Pod {
-	for _, pod := range pods {
-		ExpectCreatedWithStatus(c, pod)
-	}
-	ExpectReconcileFailed(ctx, reconciler, client.ObjectKeyFromObject(provisioner))
-	result := []*v1.Pod{}
-	for _, pod := range pods {
-		result = append(result, ExpectPodExists(c, pod.GetName(), pod.GetNamespace()))
-	}
-	return result
-}
-
-func ExpectReconcileFailed(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey) {
-	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
-	Expect(err).To(HaveOccurred())
-}
-
 func ExpectReconcileSucceeded(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey) {
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/utils/result/result.go
+++ b/pkg/utils/result/result.go
@@ -1,0 +1,17 @@
+package result
+
+import (
+	"context"
+
+	"go.uber.org/multierr"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// RetryIfError logs any errors and requeues if not nil. Supports multierr unwrapping.
+func RetryIfError(ctx context.Context, err error) (reconcile.Result, error) {
+	for _, err := range multierr.Errors(err) {
+		logging.FromContext(ctx).Errorf("Failed allocation, %s", err.Error())
+	}
+	return reconcile.Result{Requeue: err != nil}, nil
+}


### PR DESCRIPTION
**Issue, if available:**


**Description of changes:**
Before
```
karpenter-controller-59479cf58c-ngmt4 manager 2021-07-26T17:22:10.759Z	ERROR	controller.Allocation	Failed allocation, launching instances, AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; AuthFailure.ServiceLinkedRoleCreationNotPermitted; UnfulfillableCapacity; UnfulfillableCapacity; UnfulfillableCapacity; UnfulfillableCapacity; UnfulfillableCapacity; UnfulfillableCapacity
```
After 
```
karpenter-controller-68fb4db6fb-bnv5r manager 2021-07-26T17:33:48.169Z	ERROR	controller.Allocation	Failed allocation, launching instances, UnfulfillableCapacity; AuthFailure.ServiceLinkedRoleCreationNotPermitted
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
