### PR TITLE
add google analytics

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -12,6 +12,9 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
+[services.googleAnalytics]
+id = "G-NT6C9QZZQ0"
+
 # Localizations
 languageCode = "en-us"
 [languages]


### PR DESCRIPTION
**Description of changes:**
Enable google analytics. 
Add google analytics tag to hugo config.
Google analytics only be included when `HUGO_ENV="production"`

New visits to live site will be logged in google analytics, including some info about viewer. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
