### PR TITLE
enable offline search with lunrjs

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -80,6 +80,9 @@ archived_version = false
 # current doc set.
 version = "0.2"
 
+# Enable local search
+offlineSearch = true
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
**Issue, if available:**
#560 

**Description of changes:**
Enable lunr js -- https://lunrjs.com/guides/getting_started.html -- in hugo config.

When hugo is built, lunr runs and stores an index file of site contents. This is used for offline search. 

Add a search bar to the header. For example, you can search for "labels" and see relevant pages. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
