### PR TITLE
Update getting started eksctl.yaml

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -122,7 +122,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://awslabs.github.io/karpenter/charts
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false
+  --create-namespace --set serviceAccount.create=false --version 0.2.9
 ```
 
 ### Provisioner

--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -89,7 +89,6 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 First, create the IAM resources using AWS CloudFormation.
 
 ```bash
-# Creates IAM resources used by Karpenter
 TEMPOUT=$(mktemp)
 curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMPOUT \
 && aws cloudformation deploy \
@@ -99,10 +98,9 @@ curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMP
   --parameter-overrides ClusterName=${CLUSTER_NAME}
 ```
 
-Second, grant access to instances using the profile to connect to the cluster.
+Second, grant access to instances using the profile to connect to the cluster. This command adds the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.
 
 ```bash
-# Add the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.
 eksctl create iamidentitymapping \
   --username system:node:{{EC2PrivateDNSName}} \
   --cluster  ${CLUSTER_NAME} \

--- a/website/content/en/docs/getting-started/eksctl.yaml
+++ b/website/content/en/docs/getting-started/eksctl.yaml
@@ -4,7 +4,8 @@ kind: ClusterConfig
 metadata:
   name: ${CLUSTER_NAME}
   region: ${AWS_DEFAULT_REGION}
-nodeGroups:
+  version: "1.20"
+managedNodeGroups:
   - instanceType: m5.large
     name: ${CLUSTER_NAME}-ng
     desiredCapacity: 1


### PR DESCRIPTION
Switching from self managed node group to managed node group. This could help customers in the future if they keep a cluster around a while and want to update the EKS version.

Also specified the EKS version because depending on which version of `eksctl` the user has it may deploy a different version. I would use 1.21 but the official `eksctl` with 1.21 support isn't out yet. 1.20 has been covered for a while and gets us a semi-new version of a cluster to avoid unknown issues.

**Issue, if available:**


**Description of changes:**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
