### PR TITLE
Resolves race conditions exposed at high scale

### DIFF
--- a/API.md
+++ b/API.md
@@ -427,5 +427,5 @@ its target, and indicates whether or not those conditions are met.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f37f9ba</code>.
+on git commit <code>1c08b96</code>.
 </em></p>

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/controllers"
 	"github.com/awslabs/karpenter/pkg/controllers/allocation"
 	"github.com/awslabs/karpenter/pkg/controllers/expiration"
+	"github.com/awslabs/karpenter/pkg/controllers/node"
 	"github.com/awslabs/karpenter/pkg/controllers/reallocation"
 	"github.com/awslabs/karpenter/pkg/controllers/termination"
 	"github.com/go-logr/zapr"
@@ -85,6 +86,7 @@ func main() {
 		allocation.NewController(manager.GetClient(), clientSet.CoreV1(), cloudProvider),
 		reallocation.NewController(manager.GetClient(), cloudProvider),
 		termination.NewController(ctx, manager.GetClient(), clientSet.CoreV1(), cloudProvider),
+		node.NewController(manager.GetClient()),
 	).Start(ctx); err != nil {
 		panic(fmt.Sprintf("Unable to start manager, %s", err.Error()))
 	}

--- a/pkg/apis/provisioning/v1alpha3/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha3/provisioner.go
@@ -117,6 +117,9 @@ var (
 	ArchitectureLabelKey    = "kubernetes.io/arch"
 	OperatingSystemLabelKey = "kubernetes.io/os"
 
+	// Reserved taints
+	NotReadyTaintKey = SchemeGroupVersion.Group + "/not-ready"
+
 	// Reserved labels
 	ProvisionerNameLabelKey          = SchemeGroupVersion.Group + "/provisioner-name"
 	ProvisionerUnderutilizedLabelKey = SchemeGroupVersion.Group + "/underutilized"
@@ -130,7 +133,7 @@ var (
 	InstanceTypeLabelKey = "node.kubernetes.io/instance-type"
 
 	// Finalizers
-	KarpenterFinalizer = SchemeGroupVersion.Group + "/termination"
+	TerminationFinalizer = SchemeGroupVersion.Group + "/termination"
 
 	// Default provisioner
 	DefaultProvisioner = types.NamespacedName{Name: "default"}

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -78,7 +78,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 	sess := withUserAgent(session.Must(session.NewSession(
 		request.WithRetryer(
 			&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint},
-			client.DefaultRetryer{NumMaxRetries: 3},
+			client.DefaultRetryer{NumMaxRetries: client.DefaultRetryerMaxNumRetries},
 		),
 	)))
 	if *sess.Config.Region == "" {

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -74,7 +75,12 @@ type CloudProvider struct {
 }
 
 func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *CloudProvider {
-	sess := withUserAgent(session.Must(session.NewSession(&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint})))
+	sess := withUserAgent(session.Must(session.NewSession(
+		request.WithRetryer(
+			&aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint},
+			client.DefaultRetryer{NumMaxRetries: 3},
+		),
+	)))
 	if *sess.Config.Region == "" {
 		logging.FromContext(ctx).Debug("AWS region not configured, asking EC2 Instance Metadata Service")
 		*sess.Config.Region = getRegionFromIMDS(sess)

--- a/pkg/controllers/allocation/bind.go
+++ b/pkg/controllers/allocation/bind.go
@@ -45,7 +45,7 @@ func (b *Binder) Bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) error 
 	// the node by the kube scheduler, causing OutOfCPU errors when the
 	// binpacked pods race to bind to the same node. The system eventually
 	// heals, but causes delays from additional provisioning (thrash). This
-	// taint will be removed when the node is marked as ready.
+	// taint will be removed by the node controller when a node is marked ready.
 	node.Spec.Taints = append(node.Spec.Taints, v1.Taint{
 		Key:    v1alpha3.NotReadyTaintKey,
 		Effect: v1.TaintEffectNoSchedule,

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -1,0 +1,92 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewController constructs a controller instance
+func NewController(kubeClient client.Client) *Controller {
+	return &Controller{
+		kubeClient: kubeClient,
+	}
+}
+
+// Controller manages a set of properites on karpenter provisioned nodes, such as
+// taints, labels, finalizers.
+type Controller struct {
+	kubeClient client.Client
+	readiness  *Readiness
+	finalizer  *Finalizer
+}
+
+// Reconcile executes a reallocation control loop for the resource
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("Node"))
+	// 1. Retrieve node from reconcile request
+	stored := &v1.Node{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, stored); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	if len(stored.Labels[v1alpha3.ProvisionerNameLabelKey]) == 0 {
+		return reconcile.Result{}, nil
+	}
+
+	// 2. Execute node reconcilers
+	node := stored.DeepCopy()
+	var errs error
+	for _, reconciler := range []interface {
+		Reconcile(*v1.Node) error
+	}{
+		c.readiness,
+		c.finalizer,
+	} {
+		errs = multierr.Append(errs, reconciler.Reconcile(node))
+	}
+
+	// 3. Patch any changes
+	if !reflect.DeepEqual(node, stored) {
+		if err := c.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, fmt.Errorf("patching node %s, %w", node.Name, err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.
+		NewControllerManagedBy(m).
+		Named("Node").
+		For(&v1.Node{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		Complete(c)
+}

--- a/pkg/controllers/node/finalizer.go
+++ b/pkg/controllers/node/finalizer.go
@@ -1,0 +1,38 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/awslabs/karpenter/pkg/utils/functional"
+	v1 "k8s.io/api/core/v1"
+)
+
+// Finalizer is a tiny reconciler that ensures nodes have the termination
+// finalizer. This protects against instances that launch when Karpenter fails
+// to create the node object. In this case, the node will come online without
+// the termination finalizer. This controller will update the node accordingly.
+type Finalizer struct {}
+
+// Reconcile adds the termination finalizer if the node is not deleting
+func (r *Finalizer) Reconcile(n *v1.Node) error {
+	if !n.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	if !functional.ContainsString(n.Finalizers, v1alpha3.TerminationFinalizer) {
+		n.Finalizers = append(n.Finalizers, v1alpha3.TerminationFinalizer)
+	}
+	return nil
+}

--- a/pkg/controllers/node/readiness.go
+++ b/pkg/controllers/node/readiness.go
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/awslabs/karpenter/pkg/utils/node"
+	v1 "k8s.io/api/core/v1"
+)
+
+// Readiness is a tiny reconciler that removes the readiness taint when the node is ready
+type Readiness struct {}
+
+// Reconcile removes the NotReady taint when the node is ready
+func (r *Readiness) Reconcile(n *v1.Node) error {
+	if !node.IsReady(n) {
+		return nil
+	}
+	taints := []v1.Taint{}
+	for _, taint := range n.Spec.Taints {
+		if taint.Key != v1alpha3.NotReadyTaintKey {
+			taints = append(taints, taint)
+		}
+	}
+	n.Spec.Taints = taints
+	return nil
+}

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -1,0 +1,174 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Pallinder/go-randomdata"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/awslabs/karpenter/pkg/controllers/node"
+	"github.com/awslabs/karpenter/pkg/test"
+
+	. "github.com/awslabs/karpenter/pkg/test/expectations"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	. "knative.dev/pkg/logging/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var ctx context.Context
+var controller *node.Controller
+var env *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(ctx, func(e *test.Environment) {
+		controller = node.NewController(e.Client)
+	})
+	Expect(env.Start()).To(Succeed(), "Failed to start environment")
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Controller", func() {
+	AfterEach(func() {
+		ExpectCleanedUp(env.Client)
+	})
+
+	Context("Readiness", func() {
+		It("should not remove the readiness taint if not ready", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionUnknown,
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Taints: []v1.Taint{
+					{Key: v1alpha3.NotReadyTaintKey, Effect: v1.TaintEffectNoSchedule},
+					{Key: randomdata.SillyName(), Effect: v1.TaintEffectNoSchedule},
+				},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Spec.Taints).To(Equal(node.Spec.Taints))
+		})
+		It("should remove the readiness taint if ready", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionTrue,
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Taints: []v1.Taint{
+					{Key: v1alpha3.NotReadyTaintKey, Effect: v1.TaintEffectNoSchedule},
+					{Key: randomdata.SillyName(), Effect: v1.TaintEffectNoSchedule},
+				},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Spec.Taints).ToNot(Equal([]v1.Taint{node.Spec.Taints[1]}))
+		})
+		It("should do nothing if ready and the readiness taint does not exist", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionTrue,
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Taints: []v1.Taint{
+					{Key: randomdata.SillyName(), Effect: v1.TaintEffectNoSchedule},
+				},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Spec.Taints).To(Equal(node.Spec.Taints))
+		})
+		It("should do nothing if not owned by a provisioner", func() {
+			node := test.Node(test.NodeOptions{
+				ReadyStatus: v1.ConditionTrue,
+				Taints: []v1.Taint{
+					{Key: v1alpha3.NotReadyTaintKey, Effect: v1.TaintEffectNoSchedule},
+					{Key: randomdata.SillyName(), Effect: v1.TaintEffectNoSchedule},
+				},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Spec.Taints).To(Equal(node.Spec.Taints))
+		})
+	})
+	Context("Finalizer", func() {
+		It("should add the termination finalizer if missing", func() {
+			node := test.Node(test.NodeOptions{
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Finalizers: []string{"fake.com/finalizer"},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Finalizers).To(ConsistOf(node.Finalizers[0], v1alpha3.TerminationFinalizer))
+		})
+		It("should do nothing if terminating", func() {
+			node := test.Node(test.NodeOptions{
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Finalizers: []string{"fake.com/finalizer"},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Finalizers).To(Equal(node.Finalizers))
+		})
+		It("should do nothing if the termination finalizer already exists", func() {
+			node := test.Node(test.NodeOptions{
+				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: randomdata.SillyName()},
+				Finalizers: []string{v1alpha3.TerminationFinalizer, "fake.com/finalizer"},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Finalizers).To(Equal(node.Finalizers))
+		})
+		It("should do nothing if the not owned by a provisioner", func() {
+			node := test.Node(test.NodeOptions{
+				Finalizers: []string{"fake.com/finalizer"},
+			})
+			ExpectCreatedWithStatus(env.Client, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			updatedNode := &v1.Node{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Finalizers).To(Equal(node.Finalizers))
+		})
+	})
+})

--- a/pkg/controllers/reallocation/suite_test.go
+++ b/pkg/controllers/reallocation/suite_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Reallocation", func() {
 		})
 		It("should terminate underutilized nodes past their TTL", func() {
 			node := test.Node(test.NodeOptions{
-				Finalizers: []string{v1alpha3.KarpenterFinalizer},
+				Finalizers: []string{v1alpha3.TerminationFinalizer},
 				Labels: map[string]string{
 					v1alpha3.ProvisionerNameLabelKey:          provisioner.Name,
 					v1alpha3.ProvisionerUnderutilizedLabelKey: "true",
@@ -171,7 +171,7 @@ var _ = Describe("Reallocation", func() {
 		})
 		It("should only terminate nodes that failed to join with all pods terminating after 5 minutes", func() {
 			node := test.Node(test.NodeOptions{
-				Finalizers: []string{v1alpha3.KarpenterFinalizer},
+				Finalizers: []string{v1alpha3.TerminationFinalizer},
 				Labels: map[string]string{
 					v1alpha3.ProvisionerNameLabelKey:          provisioner.Name,
 					v1alpha3.ProvisionerUnderutilizedLabelKey: "true",

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -69,7 +69,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// 2. Check if node is terminable
-	if node.DeletionTimestamp.IsZero() || !functional.ContainsString(node.Finalizers, provisioning.KarpenterFinalizer) {
+	if node.DeletionTimestamp.IsZero() || !functional.ContainsString(node.Finalizers, provisioning.TerminationFinalizer) {
 		return reconcile.Result{}, nil
 	}
 	// 3. Cordon node

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Termination", func() {
 	var node *v1.Node
 
 	BeforeEach(func() {
-		node = test.Node(test.NodeOptions{Finalizers: []string{v1alpha3.KarpenterFinalizer}})
+		node = test.Node(test.NodeOptions{Finalizers: []string{v1alpha3.TerminationFinalizer}})
 	})
 
 	AfterEach(func() {

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -107,7 +107,7 @@ func (t *Terminator) terminate(ctx context.Context, node *v1.Node) error {
 	logging.FromContext(ctx).Infof("Terminated instance %s", node.Name)
 	// 2. Remove finalizer from node in APIServer
 	persisted := node.DeepCopy()
-	node.Finalizers = functional.StringSliceWithout(node.Finalizers, provisioning.KarpenterFinalizer)
+	node.Finalizers = functional.StringSliceWithout(node.Finalizers, provisioning.TerminationFinalizer)
 	if err := t.KubeClient.Patch(ctx, node, client.MergeFrom(persisted)); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("removing finalizer from node %s, %w", node.Name, err)
 	}

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -30,6 +30,7 @@ type NodeOptions struct {
 	Annotations   map[string]string
 	ReadyStatus   v1.ConditionStatus
 	Unschedulable bool
+	Taints        []v1.Taint
 	Allocatable   v1.ResourceList
 	Finalizers    []string
 }
@@ -65,6 +66,7 @@ func Node(overrides ...NodeOptions) *v1.Node {
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: options.Unschedulable,
+			Taints: options.Taints,
 		},
 		Status: v1.NodeStatus{
 			Allocatable: options.Allocatable,

--- a/pkg/utils/node/predicates.go
+++ b/pkg/utils/node/predicates.go
@@ -21,10 +21,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func IsReadyAndSchedulable(node *v1.Node) bool {
-	return IsReady(node) && !node.Spec.Unschedulable
-}
-
 func IsReady(node *v1.Node) bool {
 	return getNodeCondition(node.Status.Conditions, v1.NodeReady).Status == v1.ConditionTrue
 }

--- a/pkg/utils/result/result.go
+++ b/pkg/utils/result/result.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package result
 
 import (

--- a/pkg/utils/result/result.go
+++ b/pkg/utils/result/result.go
@@ -25,7 +25,7 @@ import (
 // RetryIfError logs any errors and requeues if not nil. Supports multierr unwrapping.
 func RetryIfError(ctx context.Context, err error) (reconcile.Result, error) {
 	for _, err := range multierr.Errors(err) {
-		logging.FromContext(ctx).Errorf("Failed allocation, %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed reconciliation, %s", err.Error())
 	}
 	return reconcile.Result{Requeue: err != nil}, nil
 }


### PR DESCRIPTION
**Issue, if available:**


**Description of changes:**
Built a lightweight controller that helps enforce invariants (over time) in the codebase.

### Case 1: Node Missing Finalizer
If kubeapi QPS is backed up, nodes may come online before we're able to create the node object. This means that the node object would be created by the kubelet, rather than patched by the kubelet. The result is that the node would not have the finalizer, and instances could leak. See: https://github.com/awslabs/karpenter/issues/549.

Now, we add the finalizer if it doesn't exist, unless the node is terminating.

### Case 2: Scheduler Racing against Provisioner
Taint karpenter.sh/not-ready=NoSchedule to prevent the kube scheduler from scheduling pods before we're able to bind them ourselves. The kube scheduler has an eventually consistent cache of nodes and pods, so it's possible for it to see a provisioned node before it sees the pods bound to it. This creates an edge case where other pending pods may be bound to the node by the kube scheduler, causing OutOfCPU errors when the binpacked pods race to bind to the same node. The system eventually heals, but causes delays from additional provisioning (thrash). This taint will be removed by the node controller when a node is marked ready.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
