### PR TITLE
add docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-request.md
+++ b/.github/ISSUE_TEMPLATE/docs-request.md
@@ -1,0 +1,18 @@
+**Is an existing page relevant?**
+<!-- provide a link -->
+
+**What karpenter features are relevant?**
+<!-- e.g., binpacking, node expiry -->
+
+**How should the docs be improved?**
+
+
+<!-- Please keep this note for the community -->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!-- Thank you for keeping this note for the community -->


### PR DESCRIPTION
**Description of changes:**
None of the existing issue templates (bug, roadmap request, security vulnerability) are a good fit for docs. 

This new issue template asks relevant questions, while also being brief. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
