### PR TITLE
switch to Bottlerocket for example eksctl nodegroup

### DIFF
--- a/website/content/en/docs/getting-started/eksctl.yaml
+++ b/website/content/en/docs/getting-started/eksctl.yaml
@@ -7,6 +7,7 @@ metadata:
   version: "1.20"
 managedNodeGroups:
   - instanceType: m5.large
+    amiFamily: Bottlerocket
     name: ${CLUSTER_NAME}-ng
     desiredCapacity: 1
     minSize: 1


### PR DESCRIPTION
**Issue, if available:** 

n/a

**Description of changes:**

it seems like using Bottlerocket as the default is preferable here, no big deal if not though

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
