### PR TITLE
Fixed a bug with liveness logic

### DIFF
--- a/pkg/controllers/node/liveness.go
+++ b/pkg/controllers/node/liveness.go
@@ -39,7 +39,8 @@ func (r *Liveness) Reconcile(ctx context.Context, provisioner *v1alpha3.Provisio
 	if Now().Sub(n.GetCreationTimestamp().Time) < LivenessTimeout {
 		return reconcile.Result{}, nil
 	}
-	if condition := node.GetCondition(n.Status.Conditions, v1.NodeReady); !condition.LastHeartbeatTime.IsZero() {
+	condition := node.GetCondition(n.Status.Conditions, v1.NodeReady);
+	if condition.Reason != "" && condition.Reason != "NodeStatusNeverUpdated" {
 		return reconcile.Result{}, nil
 	}
 	logging.FromContext(ctx).Infof("Triggering termination for node that failed to join %s", n.Name)

--- a/pkg/controllers/node/liveness.go
+++ b/pkg/controllers/node/liveness.go
@@ -40,6 +40,11 @@ func (r *Liveness) Reconcile(ctx context.Context, provisioner *v1alpha3.Provisio
 		return reconcile.Result{}, nil
 	}
 	condition := node.GetCondition(n.Status.Conditions, v1.NodeReady);
+	// If the reason is "", then the condition has never been set. We expect
+	// either the kubelet to set this reason, or the kcm's
+	// node-livecycle-controller to set the status to NodeStatusNeverUpdated if
+	// the kubelet cannot connect. Once the value is NodeStatusNeverUpdated and
+	// the node is beyond the liveness timeout, we will terminate the node.
 	if condition.Reason != "" && condition.Reason != "NodeStatusNeverUpdated" {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -215,7 +215,6 @@ var _ = Describe("Controller", func() {
 
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provisioner))
 
-			// Expect node not be deleted
 			n = ExpectNodeExists(env.Client, n.Name)
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -187,21 +187,12 @@ var _ = Describe("Controller", func() {
 				ReadyStatus: v1.ConditionUnknown,
 				ReadyReason: "NodeStatusNeverUpdated",
 			})
-			pod := test.Pod(test.PodOptions{NodeName: n.Name})
-			ExpectCreated(env.Client, provisioner, pod)
+			ExpectCreated(env.Client, provisioner)
 			ExpectCreatedWithStatus(env.Client, n)
 
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provisioner))
 
-			// Expect n not deleted
-			n = ExpectNodeExists(env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
-
-			// Delete pod and do another reconcile
-			Expect(env.Client.Delete(ctx, pod)).To(Succeed())
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provisioner))
-
-			// Expect node not deleted
+			// Expect node not be deleted
 			n = ExpectNodeExists(env.Client, n.Name)
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 
@@ -217,22 +208,14 @@ var _ = Describe("Controller", func() {
 				Finalizers:  []string{v1alpha3.TerminationFinalizer},
 				Labels:      map[string]string{v1alpha3.ProvisionerNameLabelKey: provisioner.Name},
 				ReadyStatus: v1.ConditionUnknown,
+				ReadyReason: "",
 			})
-			pod := test.Pod(test.PodOptions{NodeName: n.Name})
-			ExpectCreated(env.Client, provisioner, pod)
+			ExpectCreated(env.Client, provisioner)
 			ExpectCreatedWithStatus(env.Client, n)
 
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provisioner))
 
-			// Expect n not deleted
-			n = ExpectNodeExists(env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
-
-			// Set pod DeletionTimestamp and do another reconcile
-			Expect(env.Client.Delete(ctx, pod)).To(Succeed())
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provisioner))
-
-			// Expect node not deleted
+			// Expect node not be deleted
 			n = ExpectNodeExists(env.Client, n.Name)
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -29,6 +29,8 @@ type NodeOptions struct {
 	Labels        map[string]string
 	Annotations   map[string]string
 	ReadyStatus   v1.ConditionStatus
+	ReadyReason   string
+	Conditions    []v1.NodeCondition
 	Unschedulable bool
 	Taints        []v1.Taint
 	Allocatable   v1.ResourceList
@@ -70,7 +72,7 @@ func Node(overrides ...NodeOptions) *v1.Node {
 		},
 		Status: v1.NodeStatus{
 			Allocatable: options.Allocatable,
-			Conditions:  []v1.NodeCondition{{Type: v1.NodeReady, Status: options.ReadyStatus}},
+			Conditions:  []v1.NodeCondition{{Type: v1.NodeReady, Status: options.ReadyStatus, Reason: options.ReadyReason}},
 		},
 	}
 }


### PR DESCRIPTION
**Issue, if available:**
#613, #601

**Description of changes:**
Fixes an issue where nodes don't terminate if they can't connect to the API Server, resulting in runaway scaling. 

The liveness controller will terminate nodes that don't ready up. This is critical, because pods will only survive on not ready nodes for 5 minutes by default (tolerations). The controller must differentiate between a node that never connected (cleanup) vs a node that connected but lost connection (e.g. network partition, don't cleanup). 

The previous code assumed that the timestamp would be nil. There is a note on this here: https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/controller/nodelifecycle/node_lifecycle_controller.go#L1012. The nodelifecycle controller writes status here: https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/controller/nodelifecycle/node_lifecycle_controller.go#L1131. 

This change should catch both the case where the node controller never writes anything, as well as the case where it writes `NodeStatusNeverUpdated` which is the expected behavior.

We will continue to only take any action after the liveness timeout (5 mins). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
