### PR TITLE
Fix eksctl error in Getting Started

### DIFF
--- a/website/content/en/docs/getting-started/eksctl.yaml
+++ b/website/content/en/docs/getting-started/eksctl.yaml
@@ -7,7 +7,7 @@ metadata:
   version: "1.20"
 managedNodeGroups:
   - instanceType: m5.large
-    amiFamily: Bottlerocket
+    amiFamily: AmazonLinux2
     name: ${CLUSTER_NAME}-ng
     desiredCapacity: 1
     minSize: 1


### PR DESCRIPTION
**Issue, if available:**

**Is an existing page relevant?**
https://karpenter.sh/docs/getting-started/#create-a-cluster

**Description of issue:**
Running the command from the "Create a Cluster" section of the Getting Started guide fails with message: `Error: only AmazonLinux2 is supported for Managed Nodegroups`

**Description of change:**

Changed EKS cluster config's `amiFamily` from "Bottlerocket" to "AmazonLinux2".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

