### PR TITLE
fix link to subnet tagging in development guide

### DIFF
--- a/website/content/en/docs/development-guide.md
+++ b/website/content/en/docs/development-guide.md
@@ -34,7 +34,7 @@ make delete # Uninstall Karpenter
     * Make sure you have valid credentials to your development repository.
     * `$KO_DOCKER_REPO` must point to your development repository
     * Your cluster must have permissions to read from the repository
-* If you created your cluster on version 1.19 or above, you may need to tag your subnets as mentioned [here](docs/aws/README.md). This is a temporary problem with our subnet discovery system, and is being tracked [here](https://github.com/awslabs/karpenter/issues/404#issuecomment-845283904).
+* If you created your cluster on version 1.19 or above, you may need to tag your subnets as mentioned [here]({{< ref "{{< ref "/docs/getting-started/_index.md#tag-subnets" >}}" >}}). This is a temporary problem with our subnet discovery system, and is being tracked [here](https://github.com/awslabs/karpenter/issues/404#issuecomment-845283904).
 
 ### Build and Deploy
 ```

--- a/website/content/en/docs/development-guide.md
+++ b/website/content/en/docs/development-guide.md
@@ -34,7 +34,7 @@ make delete # Uninstall Karpenter
     * Make sure you have valid credentials to your development repository.
     * `$KO_DOCKER_REPO` must point to your development repository
     * Your cluster must have permissions to read from the repository
-* If you created your cluster on version 1.19 or above, you may need to tag your subnets as mentioned [here]({{< ref "{{< ref "/docs/getting-started/_index.md#tag-subnets" >}}" >}}). This is a temporary problem with our subnet discovery system, and is being tracked [here](https://github.com/awslabs/karpenter/issues/404#issuecomment-845283904).
+* If you created your cluster on version 1.19 or above, you may need to tag your subnets as mentioned [here]({{< ref "/docs/getting-started/_index.md#tag-subnets" >}}). This is a temporary problem with our subnet discovery system, and is being tracked [here](https://github.com/awslabs/karpenter/issues/404#issuecomment-845283904).
 
 ### Build and Deploy
 ```


### PR DESCRIPTION
**Issue, if available:**
in this guide https://karpenter.sh/docs/development-guide/ and the link embedded here (below) does not work:

> If you created your cluster on version 1.19 or above, you may need to tag your subnets as mentioned here.

**Description of changes:**
I changed the link to use a hugo reference, instead of linking to the old github content. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
