### PR TITLE
Delete IAM Service Account before deleting CloudFormation Stack in Getting Starting guide

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -229,6 +229,8 @@ kubectl delete node $NODE_NAME
 To avoid additional charges, remove the demo infrastructure from your AWS account.
 
 ```bash
+helm uninstall karpenter --namespace karpenter
+eksctl delete iamserviceaccount --cluster ${CLUSTER_NAME} --name karpenter --namespace karpenter
 aws cloudformation delete-stack --stack-name Karpenter-${CLUSTER_NAME}
 aws ec2 describe-launch-templates \
     | jq -r ".LaunchTemplates[].LaunchTemplateName" \


### PR DESCRIPTION
**Issue, if available:**


**Description of problem:**

See https://karpenter.sh/docs/getting-started/#cleanup

The command `aws cloudformation delete-stack [...]` succeeds on the command line but in the AWS Console the CloudFormation Stack's status changes to `DELETE_FAILED` with the reason `The following resource(s) failed to delete: [KarpenterControllerPolicy].`  The policy is used by the IAM Service Account created manually during the setup.

**Description of change:**

Before attempting to delete the CloudFormation Stack:
1. Uninstall the *karpenter* helm chart -- since it utilizes the IAM Service Account
2. Delete the IAM Service Account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
