### PR TITLE
improve bin-packing performance

### DIFF
--- a/pkg/controllers/allocation/binpacking/packable.go
+++ b/pkg/controllers/allocation/binpacking/packable.go
@@ -87,7 +87,7 @@ func PackableFor(i cloudprovider.InstanceType) *Packable {
 
 // Pack attempts to pack the pods into capacity, keeping track of previously
 // packed pods. If the capacity cannot fit the pod, they are set aside.
-// pods should be sorted in descending order.
+// Pods must be sorted in descending order.
 func (p *Packable) Pack(pods []*v1.Pod) *Result {
 	result := &Result{}
 	for i, pod := range pods {

--- a/pkg/controllers/allocation/binpacking/packable.go
+++ b/pkg/controllers/allocation/binpacking/packable.go
@@ -95,7 +95,7 @@ func (p *Packable) Pack(pods []*v1.Pod) *Result {
 			result.packed = append(result.packed, pod)
 			continue
 		}
-		if p.isFull(pods[len(pods)-1]) {
+		if p.fits(pods[len(pods)-1]) {
 			result.unpacked = append(result.unpacked, pods[i:]...)
 			return result
 		}
@@ -109,12 +109,11 @@ func (p *Packable) Pack(pods []*v1.Pod) *Result {
 	return result
 }
 
-// isFull checks if the reserved resources + the minimum resourced pod overflows the total resources available.
-func (p *Packable) isFull(minPod *v1.Pod) bool {
-	minResourceList := resources.RequestsForPods(minPod)
+// fits checks if the reserved resources + the pod overflows the total resources available.s
+func (p *Packable) fits(pod *v1.Pod) bool {
+	minResourceList := resources.RequestsForPods(pod)
 	for resourceName, totalQuantity := range p.total {
 		reservedQuantity := p.reserved[resourceName].DeepCopy()
-		// Add the minimum resourced pod to reserved
 		reservedQuantity.Add(minResourceList[resourceName])
 		if !totalQuantity.IsZero() && reservedQuantity.Cmp(totalQuantity) >= 0 {
 			return true

--- a/pkg/controllers/allocation/binpacking/packable.go
+++ b/pkg/controllers/allocation/binpacking/packable.go
@@ -95,17 +95,16 @@ func (p *Packable) Pack(pods []*v1.Pod) *Result {
 			result.packed = append(result.packed, pod)
 			continue
 		}
+		if p.isFull(pods[len(pods)-1]) {
+			result.unpacked = append(result.unpacked, pods[i:]...)
+			return result
+		}
 		// if largest pod can't be packed, set it aside
 		if len(result.packed) == 0 {
 			result.unpacked = append(result.unpacked, pods...)
 			return result
 		}
 		result.unpacked = append(result.unpacked, pod)
-
-		if p.isFull(pods[len(pods)-1]) {
-			result.unpacked = append(result.unpacked, pods[i+1:]...)
-			return result
-		}
 	}
 	return result
 }

--- a/pkg/controllers/allocation/binpacking/packer.go
+++ b/pkg/controllers/allocation/binpacking/packer.go
@@ -152,8 +152,9 @@ func sortByResources(instanceTypes []cloudprovider.InstanceType) {
 func weightOf(instanceType cloudprovider.InstanceType) float64 {
 	return euclidean(
 		float64(instanceType.CPU().Value()),
-		float64(instanceType.Memory().ScaledValue(resource.Mega)), // 1 gb = 1 cpu
+		float64(instanceType.Memory().ScaledValue(resource.Giga)), // 1 gb = 1 cpu
 		float64(instanceType.NvidiaGPUs().Value())*1000,           // Heavily weigh gpus x 1000
+		float64(instanceType.AMDGPUs().Value())*1000,              // Heavily weigh gpus x1000
 		float64(instanceType.AWSNeurons().Value())*1000,           // Heavily weigh neurons x1000
 	)
 }


### PR DESCRIPTION
**Issue, if available:**
https://github.com/awslabs/karpenter/issues/625

**Description of changes:**
 - Increased performance of bin-packing. This specific optimization found a loop where a terminable case was not being checked which allowed a significant number of loop iterations to be skipped. 
   - The loop was responsible for packing pods on to a specific packable node. Once the node was full, the loop would continue unnecessarily. This change also adds another small optimization to the check to determine if the node is full by passing through the smallest pod from the list (it's already sorted when passed thru) and adds it to the currently reserved resources in order to see if anymore progress could possibly be made by continuing through the loop. 
   
- The terminable case optimization in the packing loop had a 30x improvement
- The smaller "min-pod" optimization resulted in a 50% improvement

**Benchmarks:**
   - 20,000 pods previously took 91 seconds and now takes about 3 seconds and drastically reduces memory usage. NOTE: the benchmark graph "post-optimization" was ran before the minPod optimization which reduced the 20,000 pod case from around 6 seconds to 3 seconds. The benchmarks were executed on 2 m5.large instance types. 

![graphs](https://github.com/bwagner5/karpenter/raw/images/benchmark_graphs.jpg)

**Testing:**
 - Performed A/B testing w/ 1:1 input and both gave the same output.  The specific test walked up cpu, memory, and pods to pack in increments of 100 milli-cores, 64mb, and 1 respectively.  The upper limits were 10,000 mc, 8GB, and 90 pods respectively. 
 - A/B tests on multiple node packings were also performed ad-hoc.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
