### PR TITLE
update development guide

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -8,18 +8,12 @@ main() {
 }
 
 tools() {
-    # Before installing tools check that the environment has been configured.
-    if [[ -z "$GOPATH" ]]; then
-        echo "error: GOPATH is not set."
-        exit 1
-    fi
-
     cd tools
     go mod tidy
     GO111MODULE=on cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % go install %
 
-    if ! echo "$PATH" | grep -q "$GOPATH/bin"; then
-        echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\$GOPATH/bin\"'."
+    if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
+        echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."
     fi
 }
 

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -8,9 +8,19 @@ main() {
 }
 
 tools() {
+    # Before installing tools check that the environment has been configured.
+    if [[ -z "$GOPATH" ]]; then
+        echo "error: GOPATH is not set."
+        exit 1
+    fi
+
     cd tools
     go mod tidy
     GO111MODULE=on cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % go install %
+
+    if ! echo "$PATH" | grep -q "$GOPATH/bin"; then
+        echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\$GOPATH/bin\"'."
+    fi
 }
 
 kubebuilder() {

--- a/website/content/en/docs/development-guide.md
+++ b/website/content/en/docs/development-guide.md
@@ -13,7 +13,7 @@ The following tools are required for contributing to the Karpenter project.
 | [go](https://golang.org/dl/)                                       | v1.15.3+ | [Instructions](https://golang.org/doc/install)   |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |          | `brew install kubectl` |
 | [helm](https://helm.sh/docs/intro/install/)                        |          | `brew install helm`    |
-| Other tools                                                        |          | `make toolchain`       |
+| Other tools                                                        |          | `make toolchain` then ensure `PATH` contains Go workspace's `bin` |
 
 ## Developing
 
@@ -39,6 +39,7 @@ make delete # Uninstall Karpenter
 ### Build and Deploy
 ```
 make dev                                  # build and test code
+kubectl create namespace karpenter        # create target namespace for deployment
 make apply                                # deploy local changes to cluster
 CLOUD_PROVIDER=<YOUR_PROVIDER> make apply # deploy for your cloud provider
 ```

--- a/website/content/en/docs/development-guide.md
+++ b/website/content/en/docs/development-guide.md
@@ -13,7 +13,7 @@ The following tools are required for contributing to the Karpenter project.
 | [go](https://golang.org/dl/)                                       | v1.15.3+ | [Instructions](https://golang.org/doc/install)   |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |          | `brew install kubectl` |
 | [helm](https://helm.sh/docs/intro/install/)                        |          | `brew install helm`    |
-| Other tools                                                        |          | `make toolchain` then ensure `PATH` contains Go workspace's `bin` |
+| Other tools                                                        |          | `make toolchain`       |
 
 ## Developing
 


### PR DESCRIPTION
**Issue, if available:**

**Description of problem(s):**
1. `make codegen` fails, even after running `make toolchain`, because of missing executables
2. `make apply` fails because cluster namespace, "karpenter", does not exist

**Description of changes:**
1. Add instruction to update `PATH` with Go workspace's `bin` after running `make toolchain`
2. Add instruction to create namespace, "karpenter"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
