### PR TITLE
Added success logging to the provisioner

### DIFF
--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -38,10 +38,6 @@ func (f *Filter) GetProvisionablePods(ctx context.Context, provisioner *v1alpha3
 	if err := f.KubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": ""}); err != nil {
 		return nil, fmt.Errorf("listing unscheduled pods, %w", err)
 	}
-	if len(pods.Items) == 0 {
-		return nil, nil
-	}
-
 	// 2. Filter pods that aren't provisionable
 	provisionable := []*v1.Pod{}
 	for _, p := range pods.Items {
@@ -53,7 +49,6 @@ func (f *Filter) GetProvisionablePods(ctx context.Context, provisioner *v1alpha3
 		}
 		provisionable = append(provisionable, ptr.Pod(p))
 	}
-	logging.FromContext(ctx).Infof("Found %d provisionable pods", len(provisionable))
 	return provisionable, nil
 }
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/656

**2. Description of changes:**
```
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:22.851Z	ERROR	controller.allocation.provisioner/default	Failed reconciliation, getting subnets, no subnets exist given constraints	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:22.852Z	INFO	controller.allocation.provisioner/default	Watching for pod events	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:32.853Z	INFO	controller.allocation.provisioner/default	Starting provisioning loop	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:32.853Z	INFO	controller.allocation.provisioner/default	Waiting to batch additional pods	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:33.870Z	INFO	controller.allocation.provisioner/default	Found 1 provisionable pods	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:33.894Z	INFO	controller.allocation.provisioner/default	Computed packing for 1 pod(s) with instance type option(s) [t3.micro t3a.micro t3.small c1.medium t3a.small t3.medium t3a.medium c5a.large c5ad.large c4.large c5d.large c3.large c5.large c5n.large m1.large m5.large m3.large m4.large m5d.large m5a.large]	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:33.894Z	ERROR	controller.allocation.provisioner/default	Failed reconciliation, getting subnets, no subnets exist given constraints	{"commit": "eb5139e"}
karpenter-controller-7cdf8884cf-psvb9 manager 2021-09-08T21:43:33.894Z	INFO	controller.allocation.provisioner/default	Watching for pod events	{"commit": "eb5139e"}
```

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
