### PR TITLE
Amazon Linux 2 as default AMI

### DIFF
--- a/designs/aws-launch-templates-options.md
+++ b/designs/aws-launch-templates-options.md
@@ -219,11 +219,10 @@ spec:
 ```
 
 Then it could ignore that pending pod since there is no way it could
-possibly work. Another possiblity is that it could ignore the launch
-template `node.k8s.aws/launch-template-name` for that pod and revert to
-the default dynamically-generated
-([Bottlerocket](https://aws.amazon.com/bottlerocket/)) launch template
-that would work for that architecture.
+possibly work. Another possibility is that it could ignore the launch
+template `node.k8s.aws/launch-template-name` for that pod and revert
+to the default, dynamically-generated launch template that would work
+for that architecture.
 
 
 ## Recommendation

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -53,8 +53,7 @@ func (p *AMIProvider) Get(ctx context.Context, constraints *Constraints) (string
 	if *constraints.Architecture == v1alpha3.ArchitectureArm64 {
 		architectureSuffix = "-arm64"
 	}
-	// TODO: support for the "amazon-linux-2-gpu" AMI for nvidia use
-	// cases
+	// TODO: support for the "amazon-linux-2-gpu" AMI for nvidia use cases
 	name := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2%s/recommended/image_id", version, architectureSuffix)
 	if id, ok := p.cache.Get(name); ok {
 		return id.(string), nil

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -15,6 +15,7 @@ limitations under the License.
 package aws
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"github.com/patrickmn/go-cache"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -48,7 +50,13 @@ func (p *AMIProvider) Get(ctx context.Context, constraints *Constraints) (string
 	if err != nil {
 		return "", fmt.Errorf("kube server version, %w", err)
 	}
-	name := fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", version, KubeToAWSArchitectures[*constraints.Architecture])
+	var architectureSuffix bytes.Buffer
+	if *constraints.Architecture == v1alpha3.ArchitectureArm64 {
+		architectureSuffix.WriteString("-arm64")
+	}
+	// TODO: support for the "amazon-linux-2-gpu" AMI for nvidia use
+	// cases
+	name := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2%s/recommended/image_id", version, architectureSuffix.String())
 	if id, ok := p.cache.Get(name); ok {
 		return id.(string), nil
 	}

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -50,13 +50,13 @@ func (p *AMIProvider) Get(ctx context.Context, constraints *Constraints) (string
 	if err != nil {
 		return "", fmt.Errorf("kube server version, %w", err)
 	}
-	var architectureSuffix bytes.Buffer
+	var architectureSuffix string
 	if *constraints.Architecture == v1alpha3.ArchitectureArm64 {
-		architectureSuffix.WriteString("-arm64")
+		architectureSuffix = "-arm64"
 	}
 	// TODO: support for the "amazon-linux-2-gpu" AMI for nvidia use
 	// cases
-	name := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2%s/recommended/image_id", version, architectureSuffix.String())
+	name := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2%s/recommended/image_id", version, architectureSuffix)
 	if id, ok := p.cache.Get(name); ok {
 		return id.(string), nil
 	}

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -15,7 +15,6 @@ limitations under the License.
 package aws
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -219,7 +219,7 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 				nodeLabelArgs.WriteString(",")
 			}
 			first = false
-			nodeLabelArgs.WriteString(fmt.Sprintf("%s=%v\n", k, v))
+			nodeLabelArgs.WriteString(fmt.Sprintf("%s=%v", k, v))
 		}
 	}
 	var nodeTaintsArgs bytes.Buffer
@@ -234,7 +234,7 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 			nodeTaintsArgs.WriteString(fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
 		}
 	}
-	kubeletExtraArgs := strings.Join([]string{nodeLabelArgs.String(), nodeTaintsArgs.String()}, " ")
+	kubeletExtraArgs := strings.TrimRight(strings.Join([]string{nodeLabelArgs.String(), nodeTaintsArgs.String()}, " "), " ")
 	if len(kubeletExtraArgs) > 1 { // Join adds separator always
 		userData.WriteString(fmt.Sprintf(` \
     --kubelet-extra-args '%s'`, kubeletExtraArgs))

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -195,9 +195,9 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, provisioner *v
 	var userData bytes.Buffer
 	userData.WriteString(fmt.Sprintf(`#!/bin/bash
 yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-/etc/eks/bootstrap.sh %s \
+/etc/eks/bootstrap.sh '%s' \
     --container-runtime containerd \
-    --apiserver-endpoint %s`,
+    --apiserver-endpoint '%s'`,
 		*provisioner.Spec.Cluster.Name,
 		provisioner.Spec.Cluster.Endpoint))
 
@@ -205,9 +205,9 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 	if err != nil {
 		return "", fmt.Errorf("getting ca bundle for user data, %w", err)
 	}
-	if caBundle != nil && len(*caBundle) > 0 {
+	if caBundle != nil {
 		userData.WriteString(fmt.Sprintf(` \
-    --b64-cluster-ca %s`,
+    --b64-cluster-ca '%s'`,
 			*caBundle))
 	}
 	var nodeLabelArgs bytes.Buffer
@@ -234,8 +234,8 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 			nodeTaintsArgs.WriteString(fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
 		}
 	}
-	kubeletExtraArgs := strings.TrimRight(strings.Join([]string{nodeLabelArgs.String(), nodeTaintsArgs.String()}, " "), " ")
-	if len(kubeletExtraArgs) > 1 { // Join adds separator always
+	kubeletExtraArgs := strings.Trim(strings.Join([]string{nodeLabelArgs.String(), nodeTaintsArgs.String()}, " "), " ")
+	if len(kubeletExtraArgs) > 0 {
 		userData.WriteString(fmt.Sprintf(` \
     --kubelet-extra-args '%s'`, kubeletExtraArgs))
 	}

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -206,9 +206,9 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 		return "", fmt.Errorf("getting ca bundle for user data, %w", err)
 	}
 	if caBundle != nil && len(*caBundle) > 0 {
-		userData.WriteString(fmt.Sprintf(`\
+		userData.WriteString(fmt.Sprintf(` \
     --b64-cluster-ca %s`,
-			*provisioner.Spec.Cluster.CABundle))
+			*caBundle))
 	}
 	var nodeLabelArgs bytes.Buffer
 	if len(constraints.Labels) > 0 {
@@ -236,7 +236,7 @@ yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/li
 	}
 	kubeletExtraArgs := strings.Join([]string{nodeLabelArgs.String(), nodeTaintsArgs.String()}, " ")
 	if len(kubeletExtraArgs) > 1 { // Join adds separator always
-		userData.WriteString(fmt.Sprintf(`\
+		userData.WriteString(fmt.Sprintf(` \
     --kubelet-extra-args '%s'`, kubeletExtraArgs))
 	}
 	return base64.StdEncoding.EncodeToString(userData.Bytes()), nil

--- a/website/content/en/docs/provisioner-crd.md
+++ b/website/content/en/docs/provisioner-crd.md
@@ -34,8 +34,8 @@ spec:
   labels:
     ##### AWS Specific #####
     # Constrain node launch template ('$Default' version always used).
-    # If not specified, Karpenter will generate a Bottlerocket-
-    # based launch template dynamically.
+    # If not specified, Karpenter will generate a default launch template,
+	# dynamically.
     node.k8s.aws/launch-template-name: "my-launch-template-name"
     # Constrain node capacity type, default="on-demand"
     node.k8s.aws/capacity-type: "spot"

--- a/website/content/en/docs/provisioner-crd.md
+++ b/website/content/en/docs/provisioner-crd.md
@@ -35,7 +35,7 @@ spec:
     ##### AWS Specific #####
     # Constrain node launch template ('$Default' version always used).
     # If not specified, Karpenter will generate a default launch template,
-	# dynamically.
+    # dynamically.
     node.k8s.aws/launch-template-name: "my-launch-template-name"
     # Constrain node capacity type, default="on-demand"
     node.k8s.aws/capacity-type: "spot"


### PR DESCRIPTION
**1. Issue, if available:**

https://github.com/awslabs/karpenter/issues/626

**2. Description of changes:**

Changing the default Launch Template to use alinux2, for now. Will re-add support for Bottlerocket as part of further enhancements to the Launch template. 

Tested by launching nodes that only had taints, only had labels, had both taints and labels, and also ones that had neither.

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
