### PR TITLE
Ignores stuck pods rather than deleting them to avoid stateful set edge cases

### DIFF
--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -17,7 +17,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"github.com/awslabs/karpenter/pkg/utils/result"
@@ -36,9 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-// Now is a time.Now() that may be mocked by tests.
-var Now = time.Now
 
 // NewController constructs a controller instance
 func NewController(kubeClient client.Client) *Controller {

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"github.com/awslabs/karpenter/pkg/utils/functional"
+	"github.com/awslabs/karpenter/pkg/utils/injectabletime"
 	"github.com/awslabs/karpenter/pkg/utils/node"
 	"github.com/awslabs/karpenter/pkg/utils/pod"
 	"github.com/awslabs/karpenter/pkg/utils/ptr"
@@ -62,7 +63,7 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha3.Provisi
 	n.Annotations = functional.UnionStringMaps(n.Annotations)
 	ttl := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsAfterEmpty)) * time.Second
 	if !hasEmptinessTimestamp {
-		n.Annotations[v1alpha3.EmptinessTimestampAnnotationKey] = Now().Format(time.RFC3339)
+		n.Annotations[v1alpha3.EmptinessTimestampAnnotationKey] = injectabletime.Now().Format(time.RFC3339)
 		logging.FromContext(ctx).Infof("Added TTL to empty node %s", n.Name)
 		return reconcile.Result{RequeueAfter: ttl}, nil
 	}
@@ -71,7 +72,7 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha3.Provisi
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("parsing emptiness timestamp, %s", emptinessTimestamp)
 	}
-	if Now().After(emptinessTime.Add(ttl)) {
+	if injectabletime.Now().After(emptinessTime.Add(ttl)) {
 		logging.FromContext(ctx).Infof("Triggering termination after %s for empty node %s", ttl, n.Name)
 		if err := r.kubeClient.Delete(ctx, n); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deleting node %s, %w", n.Name, err)

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/awslabs/karpenter/pkg/utils/injectabletime"
 	"github.com/awslabs/karpenter/pkg/utils/ptr"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
@@ -41,7 +42,7 @@ func (r *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha3.Provis
 	// 2. Trigger termination workflow if expired
 	expirationTTL := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsUntilExpired)) * time.Second
 	expirationTime := node.CreationTimestamp.Add(expirationTTL)
-	if Now().After(expirationTime) {
+	if injectabletime.Now().After(expirationTime) {
 		logging.FromContext(ctx).Infof("Triggering termination for expired node %s after %s (+%s)", node.Name, expirationTTL, time.Since(expirationTime))
 		if err := r.kubeClient.Delete(ctx, node); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)

--- a/pkg/controllers/node/liveness.go
+++ b/pkg/controllers/node/liveness.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
+	"github.com/awslabs/karpenter/pkg/utils/injectabletime"
 	"github.com/awslabs/karpenter/pkg/utils/node"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
@@ -36,7 +37,7 @@ type Liveness struct {
 
 // Reconcile reconciles the node
 func (r *Liveness) Reconcile(ctx context.Context, provisioner *v1alpha3.Provisioner, n *v1.Node) (reconcile.Result, error) {
-	if Now().Sub(n.GetCreationTimestamp().Time) < LivenessTimeout {
+	if injectabletime.Now().Sub(n.GetCreationTimestamp().Time) < LivenessTimeout {
 		return reconcile.Result{}, nil
 	}
 	condition := node.GetCondition(n.Status.Conditions, v1.NodeReady)

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha3"
 	"github.com/awslabs/karpenter/pkg/controllers/node"
 	"github.com/awslabs/karpenter/pkg/test"
+	"github.com/awslabs/karpenter/pkg/utils/injectabletime"
 
 	. "github.com/awslabs/karpenter/pkg/test/expectations"
 	. "github.com/onsi/ginkgo"
@@ -66,7 +67,7 @@ var _ = Describe("Controller", func() {
 	})
 
 	AfterEach(func() {
-		node.Now = time.Now
+		injectabletime.Now = time.Now
 		ExpectCleanedUp(env.Client)
 	})
 
@@ -108,7 +109,7 @@ var _ = Describe("Controller", func() {
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 
 			// Simulate time passing
-			node.Now = func() time.Time {
+			injectabletime.Now = func() time.Time {
 				return time.Now().Add(time.Duration(*provisioner.Spec.TTLSecondsUntilExpired) * time.Second)
 			}
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
@@ -197,7 +198,7 @@ var _ = Describe("Controller", func() {
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 
 			// Simulate time passing and a n failing to join
-			node.Now = func() time.Time { return time.Now().Add(node.LivenessTimeout) }
+			injectabletime.Now = func() time.Time { return time.Now().Add(node.LivenessTimeout) }
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
 
 			n = ExpectNodeExists(env.Client, n.Name)
@@ -219,7 +220,7 @@ var _ = Describe("Controller", func() {
 			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
 
 			// Simulate time passing and a n failing to join
-			node.Now = func() time.Time { return time.Now().Add(node.LivenessTimeout) }
+			injectabletime.Now = func() time.Time { return time.Now().Add(node.LivenessTimeout) }
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
 
 			n = ExpectNodeExists(env.Client, n.Name)

--- a/pkg/utils/injectabletime/time.go
+++ b/pkg/utils/injectabletime/time.go
@@ -1,0 +1,6 @@
+package injectabletime
+
+import "time"
+
+// Now is a time.Now() that may be mocked by tests.
+var Now = time.Now


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
@anguslees pointed out that we must allow the kubelet to delete pods that are terminating to avoid violating stateful set guarantees if a kubelet is partitioned. Instead, we simply ignore pods that are past their grace window and delete the node. This ensures the guarantee is met, since the pod will be deleted by KCM once the node no longer exists.

### Testing
1. Modified my provisioner to have a bad endpoint.
2. Created pod
3. Node came online, didn't connect
4. Pod tolerations ran out after 5 minute, pod evicted (w/ grace period 30 sec default)
5. Node deleted by liveness controller (hanging)
6. Node waits for pod to terminate (grace period)
7. Node deleted by termination controller
8. Pod cleaned up by KCM (2 minutes later)


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
