### PR TITLE
remove yum install of ssm-agent

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -194,7 +194,6 @@ func (p *LaunchTemplateProvider) getSecurityGroupIds(ctx context.Context, provis
 func (p *LaunchTemplateProvider) getUserData(ctx context.Context, provisioner *v1alpha3.Provisioner, constraints *Constraints) (string, error) {
 	var userData bytes.Buffer
 	userData.WriteString(fmt.Sprintf(`#!/bin/bash
-yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 /etc/eks/bootstrap.sh '%s' \
     --container-runtime containerd \
     --apiserver-endpoint '%s'`,


### PR DESCRIPTION

**1. Issue, if available:**

n/a

**2. Description of changes:**

launch template generated by Karpenter no longer includes `yum install` of ssm-agent, which has been present in the eks optimized ami since https://github.com/awslabs/amazon-eks-ami/releases/tag/v20210621 has it already


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
