### PR TITLE
add allocation scheduling duration metric

### DIFF
--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -56,7 +56,7 @@ type Controller struct {
 	Batcher       *Batcher
 	Filter        *Filter
 	Binder        Binder
-	Scheduler     *scheduling.Scheduler
+	Scheduler     scheduling.Scheduler
 	Packer        binpacking.Packer
 	CloudProvider cloudprovider.CloudProvider
 	KubeClient    client.Client
@@ -68,7 +68,7 @@ func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface
 		Filter:        &Filter{KubeClient: kubeClient},
 		Binder:        DecorateBinderMetrics(NewBinder(kubeClient, coreV1Client)),
 		Batcher:       NewBatcher(maxBatchWindow, batchIdleTimeout),
-		Scheduler:     scheduling.NewScheduler(cloudProvider, kubeClient),
+		Scheduler:     scheduling.DecorateSchedulerMetrics(scheduling.NewScheduler(cloudProvider, kubeClient)),
 		Packer:        binpacking.NewPacker(),
 		CloudProvider: cloudProvider,
 		KubeClient:    kubeClient,

--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -56,7 +56,7 @@ type Controller struct {
 	Batcher       *Batcher
 	Filter        *Filter
 	Binder        Binder
-	Scheduler     scheduling.Scheduler
+	Scheduler     *scheduling.Scheduler
 	Packer        binpacking.Packer
 	CloudProvider cloudprovider.CloudProvider
 	KubeClient    client.Client
@@ -68,7 +68,7 @@ func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface
 		Filter:        &Filter{KubeClient: kubeClient},
 		Binder:        DecorateBinderMetrics(NewBinder(kubeClient, coreV1Client)),
 		Batcher:       NewBatcher(maxBatchWindow, batchIdleTimeout),
-		Scheduler:     scheduling.DecorateSchedulerMetrics(scheduling.NewScheduler(cloudProvider, kubeClient)),
+		Scheduler:     scheduling.NewScheduler(cloudProvider, kubeClient),
 		Packer:        binpacking.NewPacker(),
 		CloudProvider: cloudProvider,
 		KubeClient:    kubeClient,

--- a/pkg/controllers/allocation/scheduling/scheduler.go
+++ b/pkg/controllers/allocation/scheduling/scheduler.go
@@ -33,13 +33,24 @@ import (
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-type Scheduler interface {
-	Solve(context.Context, *v1alpha3.Provisioner, []*v1.Pod) ([]*Schedule, error)
+var scheduleTimeHistogramVec = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: metrics.KarpenterNamespace,
+		Subsystem: "allocation_controller",
+		Name:      "scheduling_duration_seconds",
+		Help:      "Duration of scheduling process in seconds. Broken down by provisioner and result.",
+		Buckets:   metrics.DurationBuckets(),
+	},
+	[]string{metrics.ProvisionerLabel, metrics.ResultLabel},
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(scheduleTimeHistogramVec)
 }
 
-type scheduler struct {
-	kubeClient client.Client
-	topology   *Topology
+type Scheduler struct {
+	KubeClient client.Client
+	Topology   *Topology
 }
 
 type Schedule struct {
@@ -50,22 +61,54 @@ type Schedule struct {
 	Daemons []*v1.Pod
 }
 
-func NewScheduler(cloudProvider cloudprovider.CloudProvider, kubeClient client.Client) Scheduler {
-	return &scheduler{
-		kubeClient: kubeClient,
-		topology: &Topology{
+func NewScheduler(cloudProvider cloudprovider.CloudProvider, kubeClient client.Client) *Scheduler {
+	return &Scheduler{
+		KubeClient: kubeClient,
+		Topology: &Topology{
 			cloudProvider: cloudProvider,
 			kubeClient:    kubeClient,
 		},
 	}
 }
 
-func (s *scheduler) Solve(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
+func (s *Scheduler) Solve(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
+	startTime := time.Now()
+	schedules, scheduleErr := s.solve(ctx, provisioner, pods)
+	durationSeconds := time.Since(startTime).Seconds()
+
+	result := "success"
+	if scheduleErr != nil {
+		result = "error"
+	}
+
+	provisionerName := provisioner.ObjectMeta.Name
+	observer, promErr := scheduleTimeHistogramVec.GetMetricWith(prometheus.Labels{
+		metrics.ProvisionerLabel: provisionerName,
+		metrics.ResultLabel:      result,
+	})
+	if promErr != nil {
+		logging.FromContext(ctx).Warnf(
+			"Failed to record scheduling duration metric [%s=%s, %s=%s, duration=%f]: error=%w",
+			metrics.ProvisionerLabel,
+			provisionerName,
+			metrics.ResultLabel,
+			result,
+			durationSeconds,
+			promErr,
+		)
+	} else {
+		observer.Observe(durationSeconds)
+	}
+
+	return schedules, scheduleErr
+}
+
+func (s *Scheduler) solve(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
 	// 1. Inject temporarily adds specific NodeSelectors to pods, which are then
 	// used by scheduling logic. This isn't strictly necessary, but is a useful
 	// trick to avoid passing topology decisions through the scheduling code. It
 	// lets us to treat TopologySpreadConstraints as just-in-time NodeSelectors.
-	if err := s.topology.Inject(ctx, provisioner, pods); err != nil {
+	if err := s.Topology.Inject(ctx, provisioner, pods); err != nil {
 		return nil, fmt.Errorf("injecting topology, %w", err)
 	}
 
@@ -88,7 +131,7 @@ func (s *scheduler) Solve(ctx context.Context, provisioner *v1alpha3.Provisioner
 // getSchedules separates pods into a set of schedules. All pods in each group
 // contain compatible scheduling constarints and can be deployed together on the
 // same node, or multiple similar nodes if the pods exceed one node's capacity.
-func (s *scheduler) getSchedules(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
+func (s *Scheduler) getSchedules(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
 	// schedule uniqueness is tracked by hash(Constraints)
 	schedules := map[uint64]*Schedule{}
 	for _, pod := range pods {
@@ -125,10 +168,10 @@ func (s *scheduler) getSchedules(ctx context.Context, provisioner *v1alpha3.Prov
 	return result, nil
 }
 
-func (s *scheduler) getDaemons(ctx context.Context, node *v1.Node) ([]*v1.Pod, error) {
+func (s *Scheduler) getDaemons(ctx context.Context, node *v1.Node) ([]*v1.Pod, error) {
 	// 1. Get DaemonSets
 	daemonSetList := &appsv1.DaemonSetList{}
-	if err := s.kubeClient.List(ctx, daemonSetList); err != nil {
+	if err := s.KubeClient.List(ctx, daemonSetList); err != nil {
 		return nil, fmt.Errorf("listing daemonsets, %w", err)
 	}
 
@@ -155,57 +198,4 @@ func IsSchedulable(pod *v1.Pod, node *v1.Node) bool {
 	}
 	// TODO, support node affinity
 	return true
-}
-
-type schedulerMetricsDecorator struct {
-	scheduler                Scheduler
-	scheduleTimeHistogramVec *prometheus.HistogramVec
-}
-
-func DecorateSchedulerMetrics(scheduler Scheduler) Scheduler {
-	scheduleTimeHistogramVec := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metrics.KarpenterNamespace,
-			Subsystem: "allocation_controller",
-			Name:      "scheduling_duration_seconds",
-			Help:      "Duration of scheduling process in seconds. Broken down by provisioner and result.",
-			Buckets:   metrics.DurationBuckets(),
-		},
-		[]string{metrics.ProvisionerLabel, metrics.ResultLabel},
-	)
-	crmetrics.Registry.MustRegister(scheduleTimeHistogramVec)
-
-	return &schedulerMetricsDecorator{scheduler: scheduler, scheduleTimeHistogramVec: scheduleTimeHistogramVec}
-}
-
-func (s *schedulerMetricsDecorator) Solve(ctx context.Context, provisioner *v1alpha3.Provisioner, pods []*v1.Pod) ([]*Schedule, error) {
-	startTime := time.Now()
-	schedules, scheduleErr := s.scheduler.Solve(ctx, provisioner, pods)
-	durationSeconds := time.Since(startTime).Seconds()
-
-	result := "success"
-	if scheduleErr != nil {
-		result = "error"
-	}
-
-	provisionerName := provisioner.ObjectMeta.Name
-	observer, promErr := s.scheduleTimeHistogramVec.GetMetricWith(prometheus.Labels{
-		metrics.ProvisionerLabel: provisionerName,
-		metrics.ResultLabel:      result,
-	})
-	if promErr != nil {
-		logging.FromContext(ctx).Warnf(
-			"Failed to record scheduling duration metric [%s=%s, %s=%s, duration=%f]: error=%w",
-			metrics.ProvisionerLabel,
-			provisionerName,
-			metrics.ResultLabel,
-			result,
-			durationSeconds,
-			promErr,
-		)
-	} else {
-		observer.Observe(durationSeconds)
-	}
-
-	return schedules, scheduleErr
 }

--- a/pkg/controllers/allocation/scheduling/scheduler.go
+++ b/pkg/controllers/allocation/scheduling/scheduler.go
@@ -81,20 +81,17 @@ func (s *Scheduler) Solve(ctx context.Context, provisioner *v1alpha3.Provisioner
 		result = "error"
 	}
 
-	provisionerName := provisioner.ObjectMeta.Name
-	observer, promErr := scheduleTimeHistogramVec.GetMetricWith(prometheus.Labels{
-		metrics.ProvisionerLabel: provisionerName,
+	labels := prometheus.Labels{
+		metrics.ProvisionerLabel: provisioner.ObjectMeta.Name,
 		metrics.ResultLabel:      result,
-	})
+	}
+	observer, promErr := scheduleTimeHistogramVec.GetMetricWith(labels)
 	if promErr != nil {
 		logging.FromContext(ctx).Warnf(
-			"Failed to record scheduling duration metric [%s=%s, %s=%s, duration=%f]: error=%w",
-			metrics.ProvisionerLabel,
-			provisionerName,
-			metrics.ResultLabel,
-			result,
+			"Failed to record scheduling duration metric [labels=%s, duration=%f]: error=%s",
+			labels,
 			durationSeconds,
-			promErr,
+			promErr.Error(),
 		)
 	} else {
 		observer.Observe(durationSeconds)

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,0 +1,33 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+const (
+	// Common namespace for application metrics.
+	KarpenterNamespace = "karpenter"
+
+	// Common set of metric label names.
+	ResultLabel      = "result"
+	ProvisionerLabel = "provisioner"
+)
+
+// DurationBuckets returns a []float64 of default threshold values for duration histograms.
+// Each returned slice is new and may be modified without impacting other bucket definitions.
+func DurationBuckets() []float64 {
+	// Use same bucket thresholds as controller-runtime.
+	// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.10.0/pkg/internal/controller/metrics/metrics.go#L47-L48
+	return []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+		1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60}
+}


### PR DESCRIPTION
**1. Issue, if available:**
#612 "Emit Metrics for Karpenter"

This PR does not fully resolve the issue. More changes will be needed.

**2. Description of changes:**
Add a histogram metric to record the duration of scheduling operations.

**3. Does this change impact docs?**

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: link to issue
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
