### PR TITLE
remove bind metric decorator

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 		registry.RegisterOrDie(cloudProvider)
 		controller = &allocation.Controller{
 			Filter:        &allocation.Filter{KubeClient: e.Client},
-			Binder:        allocation.NewBinder(e.Client, clientSet.CoreV1()),
+			Binder:        &allocation.Binder{KubeClient: e.Client, CoreV1Client: clientSet.CoreV1()},
 			Batcher:       allocation.NewBatcher(1*time.Millisecond, 1*time.Millisecond),
 			Scheduler:     scheduling.NewScheduler(cloudProvider, e.Client),
 			Packer:        binpacking.NewPacker(),

--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -55,7 +55,7 @@ const (
 type Controller struct {
 	Batcher       *Batcher
 	Filter        *Filter
-	Binder        Binder
+	Binder        *Binder
 	Scheduler     *scheduling.Scheduler
 	Packer        binpacking.Packer
 	CloudProvider cloudprovider.CloudProvider
@@ -66,7 +66,7 @@ type Controller struct {
 func NewController(kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider) *Controller {
 	return &Controller{
 		Filter:        &Filter{KubeClient: kubeClient},
-		Binder:        DecorateBinderMetrics(NewBinder(kubeClient, coreV1Client)),
+		Binder:        &Binder{KubeClient: kubeClient, CoreV1Client: coreV1Client},
 		Batcher:       NewBatcher(maxBatchWindow, batchIdleTimeout),
 		Scheduler:     scheduling.NewScheduler(cloudProvider, kubeClient),
 		Packer:        binpacking.NewPacker(),

--- a/pkg/controllers/allocation/scheduling/suite_test.go
+++ b/pkg/controllers/allocation/scheduling/suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 		registry.RegisterOrDie(cloudProvider)
 		controller = &allocation.Controller{
 			Filter:        &allocation.Filter{KubeClient: e.Client},
-			Binder:        allocation.NewBinder(e.Client, corev1.NewForConfigOrDie(e.Config)),
+			Binder:        &allocation.Binder{KubeClient: e.Client, CoreV1Client: corev1.NewForConfigOrDie(e.Config)},
 			Batcher:       allocation.NewBatcher(1*time.Millisecond, 1*time.Millisecond),
 			Scheduler:     scheduling.NewScheduler(cloudProvider, e.Client),
 			Packer:        binpacking.NewPacker(),

--- a/pkg/controllers/allocation/suite_test.go
+++ b/pkg/controllers/allocation/suite_test.go
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 		registry.RegisterOrDie(cloudProvider)
 		controller = &allocation.Controller{
 			Filter:        &allocation.Filter{KubeClient: e.Client},
-			Binder:        allocation.NewBinder(e.Client, corev1.NewForConfigOrDie(e.Config)),
+			Binder:        &allocation.Binder{KubeClient: e.Client, CoreV1Client: corev1.NewForConfigOrDie(e.Config)},
 			Batcher:       allocation.NewBatcher(1*time.Millisecond, 1*time.Millisecond),
 			Scheduler:     scheduling.NewScheduler(cloudProvider, e.Client),
 			Packer:        binpacking.NewPacker(),


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Remove decorator pattern from the implementation of the bind time metric to be consistent with the implementation of the scheduling time metric.

**3. Does this change impact docs?**

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: link to issue
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

