### PR TITLE
add allocation binpacking duration metric

### DIFF
--- a/pkg/controllers/allocation/binpacking/packer.go
+++ b/pkg/controllers/allocation/binpacking/packer.go
@@ -82,13 +82,10 @@ type Packing struct {
 // https://en.wikipedia.org/wiki/Bin_packing_problem#First_Fit_Decreasing_(FFD)
 func (p *packer) Pack(ctx context.Context, schedule *scheduling.Schedule, instances []cloudprovider.InstanceType) []*Packing {
 	startTime := time.Now()
-	packings := p.pack(ctx, schedule, instances)
-	packTimeHistogram.Observe(time.Since(startTime).Seconds())
+	defer func() {
+		packTimeHistogram.Observe(time.Since(startTime).Seconds())
+	}()
 
-	return packings
-}
-
-func (p *packer) pack(ctx context.Context, schedule *scheduling.Schedule, instances []cloudprovider.InstanceType) []*Packing {
 	// Sort pods in decreasing order by the amount of CPU requested, if
 	// CPU requested is equal compare memory requested.
 	sort.Sort(sort.Reverse(ByResourcesRequested{SortablePods: schedule.Pods}))


### PR DESCRIPTION
**1. Issue, if available:**
#612 "Emit Metrics for Karpenter"

This PR does not fully resolve the issue. More changes will be needed.

**2. Description of changes:**
Add a histogram metric to record the duration of binpacking operations.

**3. Does this change impact docs?**

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: link to issue
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
