### PR TITLE
Fix provisioner docs example where OS and Arch were swapped

### DIFF
--- a/website/content/en/docs/provisioner-crd.md
+++ b/website/content/en/docs/provisioner-crd.md
@@ -40,11 +40,11 @@ spec:
 
   # Constrain architectures, or use choose from all if unconstrained (recommended)
   # Overriden by pod.spec.nodeSelector["kubernetes.io/arch"]
-  architectures: [ "linux" ]
+  architectures: [ "amd64" ]
 
   # Constrain operating systems, or use choose from all if unconstrained (recommended)
   # Overriden by pod.spec.nodeSelector["kubernetes.io/os"]
-  operatingSystems: [ "amd64" ]
+  operatingSystems: [ "linux" ]
 
   # These fields vary per cloud provider, see your cloud provider specific documentation
   provider: {}


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
OS and Arch were backwards on provisioner example in docs.


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
