### PR TITLE
Exclude m6i

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -126,7 +126,7 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
 		"m3", "m4", "m5", "m6g", // General 
 		"c3", "c4", "c5", "c6g", // Compute
-		"r3" "r4", "r5", "r6g", // Memory
+		"r3", "r4", "r5", "r6g", // Memory
 		"a1", // Graviton
 		"t3", "t4", // Burstable
 		"p", "inf", "g", // Accelerators

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -125,7 +125,7 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	// TODO exclude if not available for spot
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
 		"m3", "m4", "m5", "m6g", // General 
-                "c3", "c4", "c5", "c6g", // Compute
+		"c3", "c4", "c5", "c6g", // Compute
 		"r3" "r4", "r5", "r6g", // Memory
 		"a1", // Graviton
 		"t3", "t4", // Burstable

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -124,7 +124,7 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	}
 	// TODO exclude if not available for spot
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
-		"m", "c", "r", "a", // Standard
+		"m3", "m4", "m5", "m6g", "c", "r", "a", // Standard
 		"t3", "t4", // Burstable
 		"p", "inf", "g", // Accelerators
 	)

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -124,7 +124,10 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	}
 	// TODO exclude if not available for spot
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
-		"m3", "m4", "m5", "m6g", "c", "r", "a", // Standard
+		"m3", "m4", "m5", "m6g", // General 
+                "c3", "c4", "c5", "c6g", // Compute
+		"r3" "r4", "r5", "r6g", // Memory
+		"a1", // Graviton
 		"t3", "t4", // Burstable
 		"p", "inf", "g", // Accelerators
 	)


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/673

**2. Description of changes:**
 - Hardcode more of the prefixes to filter out new m6i and potentially newer instance types that do not work with the VPC CNI.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
