### PR TITLE
use instanceProfile from aws cloudprovider constraints api

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -172,7 +172,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		LaunchTemplateName: aws.String(launchTemplateName(options)),
 		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
 			IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
-				Name: aws.String(fmt.Sprintf("KarpenterNodeInstanceProfile-%s", options.ClusterName)),
+				Name: aws.String(options.InstanceProfile),
 			},
 			TagSpecifications: []*ec2.LaunchTemplateTagSpecificationRequest{{
 				ResourceType: aws.String(ec2.ResourceTypeInstance),


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
InstanceProfile was still hardcoded in the AWS CloudProvider launch template creation code. This change uses the required "InstanceProfile" parameter from the AWS CP API.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
