### PR TITLE
Implemented NodeAffinity

### DIFF
--- a/pkg/apis/provisioning/v1alpha4/provisioner_defaults.go
+++ b/pkg/apis/provisioning/v1alpha4/provisioner_defaults.go
@@ -16,6 +16,11 @@ package v1alpha4
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/awslabs/karpenter/pkg/scheduling"
+	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
 )
 
 // SetDefaults for the provisioner
@@ -25,5 +30,24 @@ func (p *Provisioner) SetDefaults(ctx context.Context) {
 
 // Default the constraints
 func (c *Constraints) Default(ctx context.Context) {
-	DefaultingHook(ctx, c)
+	DefaultHook(ctx, c)
+}
+
+// Constrain applies the pods' scheduling constraints to the constraints.
+// Returns an error if the constraints cannot be applied.
+func (c *Constraints) Constrain(ctx context.Context, pods ...*v1.Pod) (errs error) {
+	nodeAffinity := scheduling.NodeAffinityFor(pods...)
+	for label, constraint := range map[string]*[]string{
+		v1.LabelTopologyZone:       &c.Zones,
+		v1.LabelInstanceTypeStable: &c.InstanceTypes,
+		v1.LabelArchStable:         &c.Architectures,
+		v1.LabelOSStable:           &c.OperatingSystems,
+	} {
+		values := nodeAffinity.GetLabelValues(label, *constraint, WellKnownLabels[label])
+		if len(values) == 0 {
+			errs = multierr.Append(errs, fmt.Errorf("label %s is too constrained", label))
+		}
+		*constraint = values
+	}
+	return multierr.Append(errs, ConstrainHook(ctx, c, pods...))
 }

--- a/pkg/apis/provisioning/v1alpha4/provisioner_validation_test.go
+++ b/pkg/apis/provisioning/v1alpha4/provisioner_validation_test.go
@@ -107,9 +107,10 @@ var _ = Describe("Validation", func() {
 		})
 	})
 	Context("Zones", func() {
-		SupportedZones = append(SupportedZones, "test-zone-1")
-		It("should succeed if unspecified", func() {
-			Expect(provisioner.Validate(ctx)).To(Succeed())
+		WellKnownLabels[v1.LabelTopologyZone] = append(WellKnownLabels[v1.LabelTopologyZone], "test-zone-1")
+		It("should fail if empty", func() {
+			provisioner.Spec.Zones = []string{}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 		It("should fail if not supported", func() {
 			provisioner.Spec.Zones = []string{"unknown"}
@@ -122,9 +123,10 @@ var _ = Describe("Validation", func() {
 	})
 
 	Context("InstanceTypes", func() {
-		SupportedInstanceTypes = append(SupportedInstanceTypes, "test-instance-type")
-		It("should succeed if unspecified", func() {
-			Expect(provisioner.Validate(ctx)).To(Succeed())
+		WellKnownLabels[v1.LabelInstanceTypeStable] = append(WellKnownLabels[v1.LabelInstanceTypeStable], "test-instance-type")
+		It("should fail if empty", func() {
+			provisioner.Spec.InstanceTypes = []string{}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 		It("should fail if not supported", func() {
 			provisioner.Spec.InstanceTypes = []string{"unknown"}
@@ -139,9 +141,10 @@ var _ = Describe("Validation", func() {
 	})
 
 	Context("Architecture", func() {
-		SupportedArchitectures = append(SupportedArchitectures, "test-architecture")
-		It("should succeed if unspecified", func() {
-			Expect(provisioner.Validate(ctx)).To(Succeed())
+		WellKnownLabels[v1.LabelArchStable] = append(WellKnownLabels[v1.LabelArchStable], "test-architecture")
+		It("should fail if empty", func() {
+			provisioner.Spec.Architectures = []string{}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 		It("should fail if not supported", func() {
 			provisioner.Spec.Architectures = []string{"unknown"}
@@ -154,9 +157,10 @@ var _ = Describe("Validation", func() {
 	})
 
 	Context("OperatingSystem", func() {
-		SupportedOperatingSystems = append(SupportedOperatingSystems, "test-operating-system")
-		It("should succeed if unspecified", func() {
-			Expect(provisioner.Validate(ctx)).To(Succeed())
+		WellKnownLabels[v1.LabelOSStable] = append(WellKnownLabels[v1.LabelOSStable], "test-operating-system")
+		It("should fail if empty", func() {
+			provisioner.Spec.OperatingSystems = []string{}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 		It("should fail if not supported", func() {
 			provisioner.Spec.OperatingSystems = []string{"unknown"}

--- a/pkg/apis/provisioning/v1alpha4/register.go
+++ b/pkg/apis/provisioning/v1alpha4/register.go
@@ -52,16 +52,19 @@ var (
 		v1.LabelTopologyZone,
 		v1.LabelInstanceTypeStable,
 		// Used internally by provisioning logic
-		ProvisionerNameLabelKey,
 		EmptinessTimestampAnnotationKey,
 		v1.LabelHostname,
 	}
-	SupportedArchitectures    = []string{}
-	SupportedOperatingSystems = []string{}
-	SupportedZones            = []string{}
-	SupportedInstanceTypes    = []string{}
-	ValidationHook            = func(ctx context.Context, constraints *Constraints) *apis.FieldError { return nil }
-	DefaultingHook            = func(ctx context.Context, constraints *Constraints) {}
+	// WellKnownLabels supported by karpenter and their allowable values
+	WellKnownLabels = map[string][]string{
+		v1.LabelArchStable:         {},
+		v1.LabelOSStable:           {},
+		v1.LabelTopologyZone:       {},
+		v1.LabelInstanceTypeStable: {},
+	}
+	DefaultHook = func(ctx context.Context, constraints *Constraints) {}
+	ValidateHook = func(ctx context.Context, constraints *Constraints) *apis.FieldError { return nil }
+	ConstrainHook  = func(ctx context.Context, constraints *Constraints, pods ...*v1.Pod) error { return nil }
 )
 
 var (

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	v1alpha1 "github.com/awslabs/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/awslabs/karpenter/pkg/utils/functional"
 	"github.com/patrickmn/go-cache"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -52,17 +53,13 @@ func (p *AMIProvider) getSSMParameter(ctx context.Context, constraints *v1alpha1
 		return "", fmt.Errorf("kube server version, %w", err)
 	}
 	var amiNameSuffix string
-	if len(constraints.Architectures) > 0 {
-		// select the first one if multiple supported
-		if constraints.Architectures[0] == v1alpha4.ArchitectureArm64 {
-			amiNameSuffix = "-arm64"
-		}
-	}
 	if needsGPUAmi(instanceTypes) {
-		if amiNameSuffix != "" {
+		if !functional.ContainsString(constraints.Architectures, v1alpha4.ArchitectureAmd64) {
 			return "", fmt.Errorf("no amazon-linux-2 ami available for both nvidia/neuron gpus and arm64 cpus")
 		}
 		amiNameSuffix = "-gpu"
+	} else if functional.ContainsString(constraints.Architectures, v1alpha4.ArchitectureArm64)  {
+		amiNameSuffix = "-arm64"
 	}
 	return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2%s/recommended/image_id", version, amiNameSuffix), nil
 }

--- a/pkg/cloudprovider/aws/apis/v1alpha1/constraints.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/constraints.go
@@ -55,7 +55,7 @@ type AWS struct {
 	// CapacityType for the node. If not specified, defaults to on-demand.
 	// May be overriden by pods.spec.nodeSelector["node.k8s.aws/capacityType"]
 	// +optional
-	CapacityType *string `json:"capacityType,omitempty"`
+	CapacityTypes []string `json:"capacityTypes,omitempty"`
 	// LaunchTemplate for the node. If not specified, a launch template will be generated.
 	// +optional
 	LaunchTemplate *string `json:"launchTemplate,omitempty"`

--- a/pkg/cloudprovider/aws/apis/v1alpha1/constraints_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/constraints_validation.go
@@ -19,55 +19,50 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/awslabs/karpenter/pkg/utils/functional"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
 	"knative.dev/pkg/apis"
 )
 
 func (c *Constraints) Validate(ctx context.Context) (errs *apis.FieldError) {
-	return c.AWS.validate(ctx).ViaField("provider")
+	return c.validate(ctx).ViaField("provider")
 }
 
-func (a *AWS) validate(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs.Also(
-		a.validateInstanceProfile(ctx),
-		a.validateCapacityType(ctx),
-		a.validateLaunchTemplate(ctx),
-		a.validateSubnets(ctx),
-		a.validateSecurityGroups(ctx),
-		a.Cluster.Validate(ctx).ViaField("cluster"),
+		c.validateInstanceProfile(ctx),
+		c.validateCapacityTypes(ctx),
+		c.validateLaunchTemplate(ctx),
+		c.validateSubnets(ctx),
+		c.validateSecurityGroups(ctx),
+		c.Cluster.Validate(ctx).ViaField("cluster"),
 	)
 }
 
-func (a *AWS) validateCapacityType(ctx context.Context) (errs *apis.FieldError) {
-	capacityTypes := []string{CapacityTypeSpot, CapacityTypeOnDemand}
-	if !functional.ContainsString(capacityTypes, aws.StringValue(a.CapacityType)) {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%s not in %v", aws.StringValue(a.CapacityType), capacityTypes), "capacityType"))
-	}
-	return errs
+func (c *Constraints) validateCapacityTypes(ctx context.Context) (errs *apis.FieldError) {
+	return v1alpha4.ValidateWellKnown(CapacityTypeLabel, c.CapacityTypes, "capacityTypes")
 }
 
-func (a *AWS) validateInstanceProfile(ctx context.Context) (errs *apis.FieldError) {
-	if a.InstanceProfile == "" {
+func (c *Constraints) validateInstanceProfile(ctx context.Context) (errs *apis.FieldError) {
+	if c.InstanceProfile == "" {
 		errs = errs.Also(apis.ErrMissingField("instanceProfile"))
 	}
 	return errs
 }
 
-func (a *AWS) validateLaunchTemplate(ctx context.Context) (errs *apis.FieldError) {
+func (c *Constraints) validateLaunchTemplate(ctx context.Context) (errs *apis.FieldError) {
 	// nothing to validate at the moment
 	return errs
 }
 
-func (a *AWS) validateSubnets(ctx context.Context) (errs *apis.FieldError) {
-	if a.SubnetSelector == nil {
+func (c *Constraints) validateSubnets(ctx context.Context) (errs *apis.FieldError) {
+	if c.SubnetSelector == nil {
 		errs = errs.Also(apis.ErrMissingField("subnetSelector"))
 	}
 	return errs
 }
 
-func (a *AWS) validateSecurityGroups(ctx context.Context) (errs *apis.FieldError) {
-	if a.SecurityGroupsSelector == nil {
+func (c *Constraints) validateSecurityGroups(ctx context.Context) (errs *apis.FieldError) {
+	if c.SecurityGroupsSelector == nil {
 		errs = errs.Also(apis.ErrMissingField("securityGroupSelector"))
 	}
 	return errs

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -46,4 +46,5 @@ var (
 func init() {
 	Scheme.AddKnownTypes(schema.GroupVersion{Group: v1alpha4.ExtensionsGroup, Version: "v1alpha1"}, &AWS{})
 	v1alpha4.RestrictedLabels = append(v1alpha4.RestrictedLabels, AWSLabelPrefix)
+	v1alpha4.WellKnownLabels[CapacityTypeLabel] = []string{CapacityTypeSpot, CapacityTypeOnDemand}
 }

--- a/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
@@ -28,10 +28,10 @@ func (in *AWS) DeepCopyInto(out *AWS) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	out.Cluster = in.Cluster
-	if in.CapacityType != nil {
-		in, out := &in.CapacityType, &out.CapacityType
-		*out = new(string)
-		**out = **in
+	if in.CapacityTypes != nil {
+		in, out := &in.CapacityTypes, &out.CapacityTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.LaunchTemplate != nil {
 		in, out := &in.LaunchTemplate, &out.LaunchTemplate

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -44,7 +44,9 @@ func (i *InstanceType) Zones() []string {
 func (i *InstanceType) Architectures() []string {
 	architectures := []string{}
 	for _, architecture := range i.ProcessorInfo.SupportedArchitectures {
-		architectures = append(architectures, v1alpha1.AWSToKubeArchitectures[aws.StringValue(architecture)])
+		if value, ok := v1alpha1.AWSToKubeArchitectures[aws.StringValue(architecture)]; ok {
+			architectures = append(architectures, value)
+		}
 	}
 	return architectures
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -37,14 +37,13 @@ type CloudProvider interface {
 	// GetInstanceTypes returns the instance types supported by the cloud
 	// provider limited by the provided constraints and daemons.
 	GetInstanceTypes(context.Context) ([]InstanceType, error)
-	// GetZones returns the zones supported by the cloud provider and the specified provisioner
-	GetZones(context.Context, *v1alpha4.Constraints) ([]string, error)
-	// Validate is a hook for additional validation logic. This method is not
-	// only called during Provisioner CRD validation, it is also used at
-	// provisioning time to ensure that pods are provisionable.
-	Validate(context.Context, *v1alpha4.Constraints) *apis.FieldError
-	// Default is a hook for additional defaulting logic specific.
+	// Default is a hook for additional defaulting logic at webhook time.
 	Default(context.Context, *v1alpha4.Constraints)
+	// Validate is a hook for additional validation logic at webhook time.
+	Validate(context.Context, *v1alpha4.Constraints) *apis.FieldError
+	// Constrain is a hook for additional constraint logic at runtime.
+	// Returns an error if the constraints cannot be applied.
+	Constrain(context.Context, *v1alpha4.Constraints, ...*v1.Pod) error
 }
 
 // Options are injected into cloud providers' factories

--- a/pkg/controllers/allocation/controller.go
+++ b/pkg/controllers/allocation/controller.go
@@ -112,7 +112,6 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		return result.RetryIfError(ctx, fmt.Errorf("solving scheduling constraints, %w", err))
 	}
-
 	// 5. Get Instance Types Options
 	instanceTypes, err := c.CloudProvider.GetInstanceTypes(ctx)
 	if err != nil {
@@ -131,8 +130,9 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		packing := packings[index]
 		errs[index] = <-c.CloudProvider.Create(ctx, packing.Constraints, packing.InstanceTypeOptions, func(node *v1.Node) error {
 			node.Labels = functional.UnionStringMaps(
-				map[string]string{v1alpha4.ProvisionerNameLabelKey: provisioner.Name},
+				node.Labels,
 				packing.Constraints.Labels,
+				map[string]string{v1alpha4.ProvisionerNameLabelKey: provisioner.Name},
 			)
 			node.Spec.Taints = append(node.Spec.Taints, packing.Constraints.Taints...)
 			return c.Binder.Bind(ctx, node, packing.Pods)

--- a/pkg/controllers/allocation/scheduling/constraints.go
+++ b/pkg/controllers/allocation/scheduling/constraints.go
@@ -15,56 +15,138 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
+	"github.com/awslabs/karpenter/pkg/scheduling"
 	"github.com/awslabs/karpenter/pkg/utils/functional"
+	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 )
 
-func NewConstraintsWithOverrides(constraints *v1alpha4.Constraints, pod *v1.Pod) *v1alpha4.Constraints {
-	return &v1alpha4.Constraints{
-		Provider:         constraints.Provider,
-		Labels:           functional.UnionStringMaps(constraints.Labels, pod.Spec.NodeSelector),
-		Taints:           overrideTaints(constraints.Taints, pod),
-		Zones:            GetOrDefault(v1.LabelTopologyZone, pod.Spec.NodeSelector, constraints.Zones),
-		InstanceTypes:    GetOrDefault(v1.LabelInstanceTypeStable, pod.Spec.NodeSelector, constraints.InstanceTypes),
-		Architectures:    GetOrDefault(v1.LabelArchStable, pod.Spec.NodeSelector, constraints.Architectures),
-		OperatingSystems: GetOrDefault(v1.LabelOSStable, pod.Spec.NodeSelector, constraints.OperatingSystems),
+// NewConstraints overrides the constraints with pod scheduling constraints
+func NewConstraints(ctx context.Context, constraints *v1alpha4.Constraints, pod *v1.Pod) (*v1alpha4.Constraints, error) {
+	// Validate that the pod is viable
+	if err := multierr.Combine(
+		validateAffinity(pod),
+		validateTopology(pod),
+		scheduling.Taints(constraints.Taints).Tolerates(pod),
+	); err != nil {
+		return nil, err
 	}
+
+	// Copy constraints and apply pod scheduling constraints
+	constraints = constraints.DeepCopy()
+	if err := constraints.Constrain(ctx, pod); err != nil {
+		return nil, err
+	}
+	if err := generateLabels(constraints, pod); err != nil {
+		return nil, err
+	}
+	if err := generateTaints(constraints, pod); err != nil {
+		return nil, err
+	}
+	return constraints, nil
 }
 
-// GetOrDefault uses a nodeSelector's value if exists, otherwise defaults
-func GetOrDefault(key string, nodeSelector map[string]string, defaults []string) []string {
-	// Use override if set
-	if nodeSelector != nil && len(nodeSelector[key]) > 0 {
-		return []string{nodeSelector[key]}
-	}
-	// Otherwise use defaults
-	return defaults
-}
-
-func overrideTaints(taints []v1.Taint, pod *v1.Pod) []v1.Taint {
-	overrides := []v1.Taint{}
-	// Generate taints from pod tolerations
+func generateTaints(constraints *v1alpha4.Constraints, pod *v1.Pod) error {
+	taints := scheduling.Taints(constraints.Taints)
 	for _, toleration := range pod.Spec.Tolerations {
-		// Only OpEqual is supported
+		// Only OpEqual is supported. OpExists does not make sense for
+		// provisioning -- in theory we could create a taint on the node with a
+		// random string, but it's unclear use case this would accomplish.
 		if toleration.Operator != v1.TolerationOpEqual {
 			continue
 		}
+		var generated []v1.Taint
 		// Use effect if defined, otherwise taint all effects
 		if toleration.Effect != "" {
-			overrides = append(overrides, v1.Taint{Key: toleration.Key, Value: toleration.Value, Effect: toleration.Effect})
+			generated = []v1.Taint{{Key: toleration.Key, Value: toleration.Value, Effect: toleration.Effect}}
 		} else {
-			overrides = append(overrides,
-				v1.Taint{Key: toleration.Key, Value: toleration.Value, Effect: v1.TaintEffectNoSchedule},
-				v1.Taint{Key: toleration.Key, Value: toleration.Value, Effect: v1.TaintEffectNoExecute},
-			)
+			generated = []v1.Taint{
+				{Key: toleration.Key, Value: toleration.Value, Effect: v1.TaintEffectNoSchedule},
+				{Key: toleration.Key, Value: toleration.Value, Effect: v1.TaintEffectNoExecute},
+			}
+		}
+		// Only add taints that do not already exist on constraints
+		for _, taint := range generated {
+			if !taints.Has(taint) {
+				taints = append(taints, taint)
+			}
 		}
 	}
-	// Add default taints if not overriden by pod above
-	for _, taint := range taints {
-		if !HasTaint(overrides, taint.Key) {
-			overrides = append(overrides, taint)
+	constraints.Taints = taints
+	return nil
+}
+
+func generateLabels(constraints *v1alpha4.Constraints, pod *v1.Pod) error {
+	labels := map[string]string{}
+	// Default to constraint labels
+	for key, value := range constraints.Labels {
+		labels[key] = value
+	}
+	// Override with pod labels
+	nodeAffinity := scheduling.NodeAffinityFor(pod)
+	for _, key := range nodeAffinity.GetLabels() {
+		if _, ok := v1alpha4.WellKnownLabels[key]; !ok {
+			var labelConstraints []string
+			if value, ok := constraints.Labels[key]; ok {
+				labelConstraints = append(labelConstraints, value)
+			}
+			values := nodeAffinity.GetLabelValues(key, labelConstraints)
+			if len(values) == 0 {
+				return fmt.Errorf("label %s is too constrained", key)
+			}
+			labels[key] = values[0]
 		}
 	}
-	return overrides
+	constraints.Labels = labels
+	return nil
+}
+
+func validateTopology(pod *v1.Pod) (errs error) {
+	for _, constraint := range pod.Spec.TopologySpreadConstraints {
+		if supported := []string{v1.LabelHostname, v1.LabelTopologyZone}; !functional.ContainsString(supported, constraint.TopologyKey) {
+			errs = multierr.Append(errs, fmt.Errorf("unsupported topology key, %s not in %s", constraint.TopologyKey, supported))
+		}
+	}
+	return errs
+}
+
+func validateAffinity(pod *v1.Pod) (errs error) {
+	if pod.Spec.Affinity == nil {
+		return nil
+	}
+	if pod.Spec.Affinity.PodAffinity != nil {
+		errs = multierr.Append(errs, fmt.Errorf("pod affinity is not supported"))
+	}
+	if pod.Spec.Affinity.PodAntiAffinity != nil {
+		errs = multierr.Append(errs, fmt.Errorf("pod anti-affinity is not supported"))
+	}
+	if pod.Spec.Affinity.NodeAffinity != nil {
+		for _, term := range pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			errs = multierr.Append(errs, validateNodeSelectorTerm(term.Preference, pod.Spec.NodeSelector))
+		}
+		if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			for _, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				errs = multierr.Append(errs, validateNodeSelectorTerm(term, pod.Spec.NodeSelector))
+			}
+		}
+	}
+	return errs
+}
+
+func validateNodeSelectorTerm(term v1.NodeSelectorTerm, nodeSelector map[string]string) (errs error) {
+	if term.MatchFields != nil {
+		errs = multierr.Append(errs, fmt.Errorf("matchFields is not supported"))
+	}
+	if term.MatchExpressions != nil {
+		for _, requirement := range term.MatchExpressions {
+			if !functional.ContainsString([]string{string(v1.NodeSelectorOpIn), string(v1.NodeSelectorOpNotIn)}, string(requirement.Operator)) {
+				errs = multierr.Append(errs, fmt.Errorf("unsupported operator, %s", requirement.Operator))
+			}
+		}
+	}
+	return errs
 }

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -20,7 +20,7 @@ import (
 
 	provisioning "github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
-	"github.com/awslabs/karpenter/pkg/controllers/allocation/scheduling"
+	"github.com/awslabs/karpenter/pkg/scheduling"
 	"github.com/awslabs/karpenter/pkg/utils/functional"
 	"github.com/awslabs/karpenter/pkg/utils/injectabletime"
 	"github.com/awslabs/karpenter/pkg/utils/ptr"
@@ -114,7 +114,7 @@ func (t *Terminator) getEvictablePods(pods []*v1.Pod) []*v1.Pod {
 	evictable := []*v1.Pod{}
 	for _, pod := range pods {
 		// Ignore if unschedulable is tolerated, since they will reschedule
-		if scheduling.Tolerates(pod, v1.Taint{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}) == nil {
+		if scheduling.Taints(scheduling.Taints{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}).Tolerates(pod) == nil {
 			continue
 		}
 		// Ignore if kubelet is partitioned and pods are beyond graceful termination window

--- a/pkg/scheduling/nodeaffinity.go
+++ b/pkg/scheduling/nodeaffinity.go
@@ -1,0 +1,77 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"github.com/awslabs/karpenter/pkg/utils/functional"
+	v1 "k8s.io/api/core/v1"
+)
+
+type NodeAffinity []v1.NodeSelectorRequirement
+
+// NodeAffinityFor constructs a set of requirements for the pods
+func NodeAffinityFor(pods ...*v1.Pod) (nodeAffinity NodeAffinity) {
+	for _, pod := range pods {
+		// Convert node selectors to requirements
+		for key, value := range pod.Spec.NodeSelector {
+			nodeAffinity = append(nodeAffinity, v1.NodeSelectorRequirement{Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value}})
+		}
+		if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
+			continue
+		}
+		// Preferences are treated as requirements. An outer loop will iteratively unconstrain them if unsatisfiable
+		for _, term := range pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			nodeAffinity = append(nodeAffinity, term.Preference.MatchExpressions...)
+		}
+		if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			for _, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				nodeAffinity = append(nodeAffinity, term.MatchExpressions...)
+			}
+		}
+	}
+	return nodeAffinity
+}
+
+// GetLabels returns the label keys specified by the scheduling rules
+func (n NodeAffinity) GetLabels() []string {
+	keys := map[string]bool{}
+	for _, requirement := range n {
+		keys[requirement.Key] = true
+	}
+	result := []string{}
+	for key := range keys {
+		result = append(result, key)
+	}
+	return result
+}
+
+// GetLabelValues for the provided key. Default values are used to substract options for NotIn.
+func (n NodeAffinity) GetLabelValues(label string, constraints ...[]string) []string {
+	// Intersect external constraints
+	result := functional.IntersectStringSlice(constraints...)
+	// OpIn
+	for _, requirement := range n {
+		if requirement.Key == label && requirement.Operator == v1.NodeSelectorOpIn {
+			result = functional.IntersectStringSlice(result, requirement.Values)
+		}
+	}
+	// OpNotIn
+	for _, requirement := range n {
+		if requirement.Key == label && requirement.Operator == v1.NodeSelectorOpNotIn {
+			result = functional.StringSliceWithout(result, requirement.Values...)
+		}
+	}
+	return result
+}

--- a/pkg/utils/functional/suite_test.go
+++ b/pkg/utils/functional/suite_test.go
@@ -82,4 +82,42 @@ var _ = Describe("Functional", func() {
 			Expect(UnionStringMaps(original, disjoiner, empty, uberwriter)).To(Equal(expected))
 		})
 	})
+	Context("IntersectStringSlice", func() {
+		var nilset []string
+		empty := []string{}
+		universe := []string{"a", "b", "c"}
+		subset := []string{"a", "b"}
+		overlap := []string{"a", "b", "d"}
+		disjoint := []string{"d", "e"}
+		duplicates := []string{"a", "a"}
+		Specify("nil set", func() {
+			Expect(IntersectStringSlice()).To(BeNil())
+			Expect(IntersectStringSlice(nilset)).To(BeNil())
+			Expect(IntersectStringSlice(nilset, nilset)).To(BeNil())
+			Expect(IntersectStringSlice(nilset, universe)).To(ConsistOf(universe))
+			Expect(IntersectStringSlice(universe, nilset)).To(ConsistOf(universe))
+			Expect(IntersectStringSlice(universe, nilset, nilset)).To(ConsistOf(universe))
+		})
+		Specify("empty set", func() {
+			Expect(IntersectStringSlice(empty, nilset)).To(And(BeEmpty(), Not(BeNil())))
+			Expect(IntersectStringSlice(nilset, empty)).To(And(BeEmpty(), Not(BeNil())))
+			Expect(IntersectStringSlice(universe, empty)).To(And(BeEmpty(), Not(BeNil())))
+			Expect(IntersectStringSlice(universe, universe, empty)).To(And(BeEmpty(), Not(BeNil())))
+		})
+		Specify("intersect", func() {
+			Expect(IntersectStringSlice(universe, subset)).To(ConsistOf(subset))
+			Expect(IntersectStringSlice(subset, universe)).To(ConsistOf(subset))
+			Expect(IntersectStringSlice(universe, overlap)).To(ConsistOf(subset))
+			Expect(IntersectStringSlice(overlap, universe)).To(ConsistOf(subset))
+			Expect(IntersectStringSlice(universe, disjoint)).To(And(BeEmpty(), Not(BeNil())))
+			Expect(IntersectStringSlice(disjoint, universe)).To(And(BeEmpty(), Not(BeNil())))
+			Expect(IntersectStringSlice(overlap, disjoint, universe)).To(And(BeEmpty(), Not(BeNil())))
+		})
+		Specify("duplicates", func() {
+			Expect(IntersectStringSlice(duplicates)).To(ConsistOf("a"))
+			Expect(IntersectStringSlice(duplicates, nilset)).To(ConsistOf("a"))
+			Expect(IntersectStringSlice(duplicates, universe)).To(ConsistOf("a"))
+			Expect(IntersectStringSlice(duplicates, universe, subset)).To(ConsistOf("a"))
+		})
+	})
 })


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/482


**2. Description of changes:**
- Taint and Label generation will no longer replace existing taints/labels defined on the provisioner (layered constraints vs overrides)
- Preferences are currently respected as hard constraints (may be relaxed in the future)
- [aws] Capacity Type is now Capacity Types, prioritize spot if able. This will default to on-demand if unspecified.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [X] Yes, issue opened: https://github.com/awslabs/karpenter/issues/704
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
