### PR TITLE
Fixed a typo in getting started guide.

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -165,7 +165,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provsioner CRD](/docs/provisioner-crd) for more information. For example,
+Review the [provisioner CRD](/docs/provisioner-crd) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 ```bash


### PR DESCRIPTION
**1. The issue, if available:**


**2. Description of changes:**
Fixed a typo in the getting started guide - "Provisioner", which I noticed when I go through the documentation.

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
