### PR TITLE
[WIP] filter out non-amd64 instance types when multiple architectures specified

### DIFF
--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -47,6 +47,15 @@ func NewAMIProvider(ssm ssmiface.SSMAPI, clientSet *kubernetes.Clientset) *AMIPr
 	}
 }
 
+func needsGPUAmi(is []cloudprovider.InstanceType) bool {
+	for _, i := range is {
+		if !i.NvidiaGPUs().IsZero() || !i.AWSNeurons().IsZero() {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *AMIProvider) getSSMParameter(ctx context.Context, constraints *v1alpha1.Constraints, instanceTypes []cloudprovider.InstanceType) (string, error) {
 	version, err := p.kubeServerVersion(ctx)
 	if err != nil {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -145,15 +145,6 @@ func (p *LaunchTemplateProvider) ensureLaunchTemplate(ctx context.Context, optio
 	return launchTemplate, nil
 }
 
-func needsGPUAmi(is []cloudprovider.InstanceType) bool {
-	for _, i := range is {
-		if !i.NvidiaGPUs().IsZero() || !i.AWSNeurons().IsZero() {
-			return true
-		}
-	}
-	return false
-}
-
 // needsDocker returns true if the instance type is unable to use
 // conatinerd directly
 func needsDocker(is []cloudprovider.InstanceType) bool {


### PR DESCRIPTION
**1. Issue, if available:**

https://github.com/awslabs/karpenter/issues/703

**2. Description of changes:**

when multiple architectures are specified, need to filter down to just one (because we only have one launch template); for now, use amd64 in this case

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
