### PR TITLE
AWS Cloudprovider now supports architecture flexibility in a single fleet request

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/constraints_defaults.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/constraints_defaults.go
@@ -27,7 +27,6 @@ var ClusterDiscoveryTagKeyFormat = "kubernetes.io/cluster/%s"
 
 // Default the constraints.
 func (c *Constraints) Default(ctx context.Context) {
-	c.defaultArchitectures(ctx)
 	c.defaultCapacityTypes(ctx)
 	c.defaultSubnets(ctx)
 	c.defaultSecurityGroups(ctx)
@@ -38,16 +37,6 @@ func (c *Constraints) defaultCapacityTypes(ctx context.Context) {
 		return
 	}
 	c.CapacityTypes = []string{CapacityTypeOnDemand}
-}
-
-func (c *Constraints) defaultArchitectures(ctx context.Context) {
-	if len(c.Architectures) != 0 {
-		return
-	}
-	// In practice it is rare to be able to support both amd64 and
-	// arm64 at the same time, so we default to just amd64; this could
-	// change over time as tooling and techniques improve, etc.
-	c.Architectures = []string{v1alpha4.ArchitectureAmd64}
 }
 
 func (c *Constraints) defaultSubnets(ctx context.Context) {

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -41,14 +41,13 @@ func (i *InstanceType) Zones() []string {
 	return i.ZoneOptions
 }
 
-func (i *InstanceType) Architectures() []string {
-	architectures := []string{}
+func (i *InstanceType) Architecture() string {
 	for _, architecture := range i.ProcessorInfo.SupportedArchitectures {
 		if value, ok := v1alpha1.AWSToKubeArchitectures[aws.StringValue(architecture)]; ok {
-			architectures = append(architectures, value)
+			return value
 		}
 	}
-	return architectures
+	return fmt.Sprint(aws.StringValueSlice(i.ProcessorInfo.SupportedArchitectures)) // Unrecognized, but used for error printing
 }
 
 func (i *InstanceType) OperatingSystems() []string {

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -58,7 +58,7 @@ func (c *CloudProvider) Create(ctx context.Context, constraints *v1alpha4.Constr
 			},
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
-					Architecture:    instance.Architectures()[0],
+					Architecture:    instance.Architecture(),
 					OperatingSystem: instance.OperatingSystems()[0],
 				},
 				Allocatable: v1.ResourceList{
@@ -94,8 +94,8 @@ func (c *CloudProvider) GetInstanceTypes(ctx context.Context) ([]cloudprovider.I
 			operatingSystems: []string{"windows"},
 		}),
 		NewInstanceType(InstanceTypeOptions{
-			name:          "arm-instance-type",
-			architectures: []string{"arm64"},
+			name:         "arm-instance-type",
+			architecture: "arm64",
 		}),
 	}, nil
 }

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -23,8 +23,8 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 	if len(options.zones) == 0 {
 		options.zones = []string{"test-zone-1", "test-zone-2", "test-zone-3"}
 	}
-	if len(options.architectures) == 0 {
-		options.architectures = []string{"amd64"}
+	if len(options.architecture) == 0 {
+		options.architecture = "amd64"
 	}
 	if len(options.operatingSystems) == 0 {
 		options.operatingSystems = []string{"linux"}
@@ -42,7 +42,7 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 		InstanceTypeOptions: InstanceTypeOptions{
 			name:             options.name,
 			zones:            options.zones,
-			architectures:    options.architectures,
+			architecture:     options.architecture,
 			operatingSystems: options.operatingSystems,
 			cpu:              options.cpu,
 			memory:           options.memory,
@@ -57,7 +57,7 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 type InstanceTypeOptions struct {
 	name             string
 	zones            []string
-	architectures    []string
+	architecture     string
 	operatingSystems []string
 	cpu              resource.Quantity
 	memory           resource.Quantity
@@ -79,8 +79,8 @@ func (i *InstanceType) Zones() []string {
 	return i.zones
 }
 
-func (i *InstanceType) Architectures() []string {
-	return i.architectures
+func (i *InstanceType) Architecture() string {
+	return i.architecture
 }
 
 func (i *InstanceType) OperatingSystems() []string {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -55,7 +55,7 @@ type Options struct {
 type InstanceType interface {
 	Name() string
 	Zones() []string
-	Architectures() []string
+	Architecture() string
 	OperatingSystems() []string
 	CPU() *resource.Quantity
 	Memory() *resource.Quantity

--- a/pkg/controllers/allocation/binpacking/packable.go
+++ b/pkg/controllers/allocation/binpacking/packable.go
@@ -159,8 +159,8 @@ func (p *Packable) validateInstanceType(schedule *scheduling.Schedule) error {
 }
 
 func (p *Packable) validateArchitecture(schedule *scheduling.Schedule) error {
-	if len(functional.IntersectStringSlice(p.Architectures(), schedule.Architectures)) == 0 {
-		return fmt.Errorf("architecture %s is not in %v", schedule.Architectures, p.Architectures())
+	if !functional.ContainsString(schedule.Architectures, p.Architecture()) {
+		return fmt.Errorf("architecture %s is not in %v", p.Architecture(), schedule.Architectures)
 	}
 	return nil
 }
@@ -219,4 +219,12 @@ func (p *Packable) validateAWSNeurons(schedule *scheduling.Schedule) error {
 		}
 	}
 	return fmt.Errorf("aws neuron is not required")
+}
+
+func packableNames(instanceTypes []*Packable) []string {
+	names := []string{}
+	for _, instanceType := range instanceTypes {
+		names = append(names, instanceType.Name())
+	}
+	return names
 }

--- a/pkg/controllers/allocation/scheduling/preferences.go
+++ b/pkg/controllers/allocation/scheduling/preferences.go
@@ -55,11 +55,10 @@ func (p *Preferences) relax(ctx context.Context, pod *v1.Pod) bool {
 		func(pod *v1.Pod) *string { return p.removeRequiredNodeAffinityTerm(ctx, pod) },
 	} {
 		if reason := relaxFunc(pod); reason != nil {
-			logging.FromContext(ctx).Debugf("Pod %s/%s previously failed to schedule, removing soft constraint: %s", pod.Namespace, pod.Name, ptr.StringValue(reason))
+			logging.FromContext(ctx).Debugf("Relaxing soft constraints for %s/%s since it previously failed to schedule, removing: %s", pod.Namespace, pod.Name, ptr.StringValue(reason))
 			return true
 		}
 	}
-	logging.FromContext(ctx).Debugf("Pod %s/%s previously failed to schedule, but no soft constraints remain", pod.Namespace, pod.Name)
 	return false
 }
 

--- a/pkg/controllers/allocation/scheduling/suite_test.go
+++ b/pkg/controllers/allocation/scheduling/suite_test.go
@@ -52,7 +52,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProvider := &fake.CloudProvider{}
-		registry.RegisterOrDie(cloudProvider)
+		registry.RegisterOrDie(ctx, cloudProvider)
 		controller = &allocation.Controller{
 			Filter:        &allocation.Filter{KubeClient: e.Client},
 			Binder:        &allocation.Binder{KubeClient: e.Client, CoreV1Client: corev1.NewForConfigOrDie(e.Config)},

--- a/pkg/controllers/allocation/suite_test.go
+++ b/pkg/controllers/allocation/suite_test.go
@@ -54,7 +54,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProvider := &fake.CloudProvider{}
-		registry.RegisterOrDie(cloudProvider)
+		registry.RegisterOrDie(ctx, cloudProvider)
 		controller = &allocation.Controller{
 			Filter:        &allocation.Filter{KubeClient: e.Client},
 			Binder:        &allocation.Binder{KubeClient: e.Client, CoreV1Client: corev1.NewForConfigOrDie(e.Config)},

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -53,7 +53,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProvider := &fake.CloudProvider{}
-		registry.RegisterOrDie(cloudProvider)
+		registry.RegisterOrDie(ctx, cloudProvider)
 		coreV1Client := corev1.NewForConfigOrDie(e.Config)
 		evictionQueue = termination.NewEvictionQueue(ctx, coreV1Client)
 		controller = &termination.Controller{


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/703

**2. Description of changes:**
Now separates instance types by SSM parameter and passes separate LaunchConfigs to the Fleet API.

```
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:17.055Z	INFO	controller.allocation.provisioner/default	Found 16 provisionable pods	{"commit": "551f2bf"}
 karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.336Z	DEBUG	controller.allocation.provisioner/default	Discovered 309 EC2 instance types	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.345Z	INFO	controller.allocation.provisioner/default	Computed packing for 15 pod(s) with instance type option(s) [m5.2xlarge]	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.359Z	INFO	controller.allocation.provisioner/default	Computed packing for 1 pod(s) with instance type option(s) [c6g.medium m5.2xlarge]	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.659Z	DEBUG	controller.allocation.provisioner/default	Discovered subnets: [subnet-04ffb1a3c5e6c19a3 subnet-0082841075ccc05d4 subnet-0550f22b5de615eac subnet-0f3fa09b6ca9de74a subnet-05ad119d43b8c07b3 subnet-043ae197020acadfb]	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.882Z	DEBUG	controller.allocation.provisioner/default	Discovered security groups: [sg-000d68e67c3fe53d8 sg-0c8c73058f4cbaaaa]	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.884Z	DEBUG	controller.allocation.provisioner/default	Discovered kubernetes version 1.20	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.937Z	DEBUG	controller.allocation.provisioner/default	Discovered ami ami-0494b922d4a70c8d6 for query /aws/service/eks/optimized-ami/1.20/amazon-linux-2/recommended/image_id	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.938Z	DEBUG	controller.allocation.provisioner/default	Discovered caBundle, length 1025	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:18.980Z	DEBUG	controller.allocation.provisioner/default	Discovered launch template Karpenter-etarn-10670878007216278433	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.176Z	INFO	controller.allocation.provisioner/default	Launched instance: i-0f76daeedd03b7aea, type: m5.2xlarge, zone: us-west-2b, hostname: ip-192-168-29-92.us-west-2.compute.internal	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.229Z	INFO	controller.allocation.provisioner/default	Bound 15 pod(s) to node ip-192-168-29-92.us-west-2.compute.internal	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.255Z	DEBUG	controller.allocation.provisioner/default	Discovered ami ami-029c456cf0e4bd912 for query /aws/service/eks/optimized-ami/1.20/amazon-linux-2-arm64/recommended/image_id	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.256Z	DEBUG	controller.allocation.provisioner/default	Discovered caBundle, length 1025	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.294Z	DEBUG	controller.allocation.provisioner/default	Discovered launch template Karpenter-etarn-14912319109985293255	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:22.297Z	DEBUG	controller.allocation.provisioner/default	Discovered caBundle, length 1025	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:24.239Z	INFO	controller.allocation.provisioner/default	Launched instance: i-0d841115239d55209, type: c6g.medium, zone: us-west-2a, hostname: ip-192-168-91-244.us-west-2.compute.internal	{"commit": "551f2bf"}
karpenter-controller-6c847fcb55-9cf2r manager 2021-09-29T01:05:24.256Z	INFO	controller.allocation.provisioner/default	Bound 1 pod(s) to node ip-192-168-91-244.us-west-2.compute.internal	{"commit": "551f2bf"}
```

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
