### PR TITLE
ignore static pods owned by a node in node emptiness check

### DIFF
--- a/pkg/controllers/allocation/filter.go
+++ b/pkg/controllers/allocation/filter.go
@@ -65,6 +65,9 @@ func (f *Filter) isUnschedulable(p *v1.Pod) error {
 	if pod.IsOwnedByDaemonSet(p) {
 		return fmt.Errorf("owned by daemonset")
 	}
+	if pod.IsOwnedByNode(p) {
+		return fmt.Errorf("owned by node")
+	}
 	return nil
 }
 

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -90,7 +90,7 @@ func (r *Emptiness) isEmpty(ctx context.Context, n *v1.Node) (bool, error) {
 		if pod.HasFailed(&p) {
 			continue
 		}
-		if !pod.IsOwnedByDaemonSet(&p) {
+		if !pod.IsOwnedByDaemonSet(&p) && !pod.IsOwnedByNode(&p) {
 			return false, nil
 		}
 	}

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -33,9 +33,20 @@ func HasFailed(pod *v1.Pod) bool {
 }
 
 func IsOwnedByDaemonSet(pod *v1.Pod) bool {
-	for _, ignoredOwner := range []schema.GroupVersionKind{
+	return IsOwnedBy(pod, []schema.GroupVersionKind{
 		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
-	} {
+	})
+}
+
+// IsOwnedByNode returns true if the pod is a static pod owned by a specific node
+func IsOwnedByNode(pod *v1.Pod) bool {
+	return IsOwnedBy(pod, []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Node"},
+	})
+}
+
+func IsOwnedBy(pod *v1.Pod, gvks []schema.GroupVersionKind) bool {
+	for _, ignoredOwner := range gvks {
 		for _, owner := range pod.ObjectMeta.OwnerReferences {
 			if owner.APIVersion == ignoredOwner.GroupVersion().String() && owner.Kind == ignoredOwner.Kind {
 				return true


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
I ran into a few problems running Karpenter on kOps because kube-proxy is deployed as a static pod. Static pods have owner references to the node resource they are running on. This change checks if a pod is a static pod when performing karpenter's node emptiness check. Static pods shouldn't hold up node eviction since they are effectively an agent similar to a daemonset which karpenter already ignores.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
