### PR TITLE
add kube client qps configuration w/ env vars and cli overrides

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- with .Values.controller.env }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074
       securityContext:

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// WithDefaultString returns the string value of the supplied environ variable or, if not
+// present, the supplied default value
+func WithDefaultString(key string, def string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	return val
+}
+
+// WithDefaultInt returns the int value of the supplied environ variable or, if not present,
+// the supplied default value. If the int conversion fails, returns the default
+func WithDefaultInt(key string, def int) int {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		fmt.Printf("COULDN'T FIND KEY %s", key)
+		return def
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		fmt.Printf("CONVERSION FAILED FOR %s w/ value %s", key, val)
+		return def
+	}
+	return i
+}
+
+// WithDefaultBool returns the boolvalue of the supplied environ variable or, if not present,
+// the supplied default value. If the conversion fails, returns the default
+func WithDefaultBool(key string, def bool) bool {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return def
+	}
+	return b
+}


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Allow ENV vars to be used to configure CLI args (easier w/ Helm). 
   - Precedense: CLI Arg, ENV Var, hard coded default   
 - Set default QPS for kubernetes client to 200 base, 300 burst QPS. 10x the default values to allow karpenter to bind pods to nodes without getting client-side throttled often. 

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [x] Yes, issue opened: *link to issue* 
- [ ] No

Docs Issue: https://github.com/awslabs/karpenter/issues/722

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
