### PR TITLE
Increase node liveness timeout to 15 min

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -202,7 +202,8 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 	}
 
 	var userData bytes.Buffer
-	userData.WriteString(fmt.Sprintf(`#!/bin/bash
+	userData.WriteString(fmt.Sprintf(`#!/bin/bash -xe
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh '%s' %s \
     --apiserver-endpoint '%s'`,
 		constraints.Cluster.Name,

--- a/pkg/controllers/allocation/bind.go
+++ b/pkg/controllers/allocation/bind.go
@@ -117,7 +117,6 @@ func (b *Binder) bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) error 
 }
 
 func (b *Binder) bindPod(ctx context.Context, node *v1.Node, pod *v1.Pod) error {
-	// TODO, Stop using deprecated v1.Binding
 	if err := b.CoreV1Client.Pods(pod.Namespace).Bind(ctx, &v1.Binding{
 		TypeMeta:   pod.TypeMeta,
 		ObjectMeta: pod.ObjectMeta,

--- a/pkg/controllers/node/liveness.go
+++ b/pkg/controllers/node/liveness.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const LivenessTimeout = 5 * time.Minute
+const LivenessTimeout = 15 * time.Minute
 
 // Liveness is a subreconciler that deletes nodes if its determined to be unrecoverable
 type Liveness struct {


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Output userdata script to EC2 Console for easier debugging
 - Up the node liveness timeout from 5 to 15 mins to account for custom LTs that take longer to bootstrap (like when using the default kops LT).


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
