### PR TITLE
temporarily switch back to docker for nvidia GPUs

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -150,9 +150,7 @@ func (p *LaunchTemplateProvider) ensureLaunchTemplate(ctx context.Context, optio
 // conatinerd directly
 func needsDocker(is []cloudprovider.InstanceType) bool {
 	for _, i := range is {
-		// This function can be removed once containerd support for
-		// Neurons is in the EKS Optimized AMI
-		if !i.AWSNeurons().IsZero() {
+		if !i.AWSNeurons().IsZero() || !i.NvidiaGPUs().IsZero() {
 			return true
 		}
 	}


### PR DESCRIPTION

**1. Issue, if available:**

n/a


**2. Description of changes:**

Until can figure out how to get it working - was getting errors like
so:

Oct  4 16:57:28 ip-192-168-160-221 kubelet: E1004 16:57:28.770481    8031 remote_runtime.go:86] "Version from runtime service failed" err="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /run/containerd/containerd.sock: connect: no such file or directory\""

in kubelet logs on eks gpu optimized AMI-based instances


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
