### PR TITLE
label capacity type on nodes in userdata and when creating initial node resource

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -142,8 +142,9 @@ func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, constra
 		return nil, fmt.Errorf("getting subnets, %w", err)
 	}
 
+	additionalLabels := map[string]string{v1alpha1.CapacityTypeLabel: capacityType}
 	var launchTemplateConfigs []*ec2.FleetLaunchTemplateConfigRequest
-	launchTemplates, err := p.launchTemplateProvider.Get(ctx, constraints, instanceTypes)
+	launchTemplates, err := p.launchTemplateProvider.Get(ctx, constraints, instanceTypes, additionalLabels)
 	if err != nil {
 		return nil, fmt.Errorf("getting launch templates, %w", err)
 	}
@@ -212,6 +213,9 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 			return &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: aws.StringValue(instance.PrivateDnsName),
+					Labels: map[string]string{
+						v1alpha1.CapacityTypeLabel: getCapacityType(instance),
+					},
 				},
 				Spec: v1.NodeSpec{
 					ProviderID: fmt.Sprintf("aws:///%s/%s", aws.StringValue(instance.Placement.AvailabilityZone), aws.StringValue(instance.InstanceId)),

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -220,12 +220,12 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 			*caBundle))
 	}
 
-	additionalLabels = functional.UnionStringMaps(additionalLabels, constraints.Labels)
+	nodeLabels := functional.UnionStringMaps(additionalLabels, constraints.Labels)
 	var nodeLabelArgs bytes.Buffer
-	if len(additionalLabels) > 0 {
+	if len(nodeLabels) > 0 {
 		nodeLabelArgs.WriteString("--node-labels=")
 		first := true
-		for k, v := range additionalLabels {
+		for k, v := range nodeLabels {
 			if !first {
 				nodeLabelArgs.WriteString(",")
 			}


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/713

**2. Description of changes:**
Label aws nodes w/ capacity-type via user-data (kubelet args) and when initially creating the node object.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
