### PR TITLE
add node metrics controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider/registry"
 	"github.com/awslabs/karpenter/pkg/controllers"
 	"github.com/awslabs/karpenter/pkg/controllers/allocation"
+	nodemetrics "github.com/awslabs/karpenter/pkg/controllers/metrics/node"
 	"github.com/awslabs/karpenter/pkg/controllers/node"
 	"github.com/awslabs/karpenter/pkg/controllers/termination"
 	"github.com/awslabs/karpenter/pkg/utils/env"
@@ -96,6 +97,7 @@ func main() {
 		allocation.NewController(manager.GetClient(), clientSet.CoreV1(), cloudProvider),
 		termination.NewController(ctx, manager.GetClient(), clientSet.CoreV1(), cloudProvider),
 		node.NewController(manager.GetClient()),
+		nodemetrics.NewController(manager.GetClient()),
 	).Start(ctx); err != nil {
 		panic(fmt.Sprintf("Unable to start manager, %s", err.Error()))
 	}

--- a/pkg/cloudprovider/registry/register.go
+++ b/pkg/cloudprovider/registry/register.go
@@ -33,7 +33,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) cloudp
 // architectures, and validation logic. This operation should only be called
 // once at startup time. Typically, this call is made by NewCloudProvider(), but
 // must be called if the cloud provider is constructed manually (e.g. tests).
-func RegisterOrDie(ctx context.Context,cloudProvider cloudprovider.CloudProvider) {
+func RegisterOrDie(ctx context.Context, cloudProvider cloudprovider.CloudProvider) {
 	zones := map[string]bool{}
 	architectures := map[string]bool{}
 	operatingSystems := map[string]bool{}

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -58,7 +58,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		// The provisioner has been deleted. Reset all the associated counts to zero.
-		if err := publishNodeCountsForProvisioner(provisionerName, consumeNoNodes); err != nil {
+		if err := publishNodeCountsForProvisioner(provisionerName, consumeZeroNodes); err != nil {
 			// One or more metrics were not zeroed. Try again later.
 			return reconcile.Result{Requeue: true}, err
 		}
@@ -115,7 +115,7 @@ func (c *Controller) consumeNodesWith(ctx context.Context) consumeNodesWithFunc 
 	}
 }
 
-// consumeNoNodes calls `consume` with an empty slice and returns any resulting error.
-func consumeNoNodes(_ client.MatchingLabels, consume nodeListConsumerFunc) error {
+// consumeZeroNodes calls `consume` with an empty slice and returns any resulting error.
+func consumeZeroNodes(_ client.MatchingLabels, consume nodeListConsumerFunc) error {
 	return consume([]v1.Node{})
 }

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -1,0 +1,122 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"time"
+
+	karpenterv1 "github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	controllerName = "NodeMetrics"
+
+	requeueInterval = 10 * time.Second
+)
+
+type Controller struct {
+	KubeClient client.Client
+}
+
+func NewController(kubeClient client.Client) *Controller {
+	return &Controller{KubeClient: kubeClient}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(controllerName))
+
+	provisionerName := req.NamespacedName.Name
+
+	// 1. Has the provisioner been deleted?
+	if err := c.provisionerExists(ctx, req); err != nil {
+		if !errors.IsNotFound(err) {
+			// Unable to determine existence of the provisioner, try again later.
+			return reconcile.Result{Requeue: true}, err
+		}
+
+		// The provisioner has been deleted. Reset all the associated counts to zero.
+		if err := publishNodeCountsForProvisioner(provisionerName, consumeNoNodes); err != nil {
+			// One or more metrics were not zeroed. Try again later.
+			return reconcile.Result{Requeue: true}, err
+		}
+
+		// Since the provisioner is gone, do not requeue.
+		return reconcile.Result{}, nil
+	}
+
+	// 2. Update node counts associated with this provisioner.
+	if err := publishNodeCountsForProvisioner(provisionerName, c.consumeNodesFromKubeClientWithContext(ctx)); err != nil {
+		// An updated value for one or more metrics was not published. Try again later.
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	// 3. Schedule the next run.
+	return reconcile.Result{RequeueAfter: requeueInterval}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.
+		NewControllerManagedBy(m).
+		Named(controllerName).
+		For(&karpenterv1.Provisioner{}, builder.WithPredicates(
+			predicate.Funcs{
+				CreateFunc:  func(_ event.CreateEvent) bool { return true },
+				DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+				UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
+			},
+		)).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(c)
+}
+
+// provisionerExists simply attempts to retrieve the provisioner from the Controller's Client
+// and returns any resulting error.
+func (c *Controller) provisionerExists(ctx context.Context, req reconcile.Request) error {
+	provisioner := karpenterv1.Provisioner{}
+	return c.KubeClient.Get(ctx, req.NamespacedName, &provisioner)
+}
+
+// consumeNodesFromKubeClientWithContext will retrieve matching nodes from the Controller's Client then
+// pass the nodes to `consume` and returns any resulting error. If Client returns an error when
+// retrieving nodes then the error is returned without calling `consume`.
+func (c *Controller) consumeNodesFromKubeClientWithContext(ctx context.Context) consumeNodesWithFunc {
+	return func(nodeLabels client.MatchingLabels, consume nodeListConsumerFunc) error {
+		nodes := corev1.NodeList{}
+		if err := c.KubeClient.List(ctx, &nodes, nodeLabels); err != nil {
+			return err
+		}
+		return consume(nodes.Items)
+	}
+}
+
+// consumeNoNodes calls `consume` with an empty slice and returns any resulting error.
+func consumeNoNodes(_ client.MatchingLabels, consume nodeListConsumerFunc) error {
+	return consume([]corev1.Node{})
+}

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -68,7 +68,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// 2. Update node counts associated with this provisioner.
-	if err := publishNodeCountsForProvisioner(provisionerName, c.consumeNodesFromKubeClientWithContext(ctx)); err != nil {
+	if err := publishNodeCountsForProvisioner(provisionerName, c.consumeNodesWith(ctx)); err != nil {
 		// An updated value for one or more metrics was not published. Try again later.
 		return reconcile.Result{Requeue: true}, err
 	}
@@ -102,10 +102,10 @@ func (c *Controller) provisionerExists(ctx context.Context, req reconcile.Reques
 	return c.KubeClient.Get(ctx, req.NamespacedName, &provisioner)
 }
 
-// consumeNodesFromKubeClientWithContext will retrieve matching nodes from the Controller's Client then
+// consumeNodesWith will retrieve matching nodes from the Controller's Client then
 // pass the nodes to `consume` and returns any resulting error. If Client returns an error when
 // retrieving nodes then the error is returned without calling `consume`.
-func (c *Controller) consumeNodesFromKubeClientWithContext(ctx context.Context) consumeNodesWithFunc {
+func (c *Controller) consumeNodesWith(ctx context.Context) consumeNodesWithFunc {
 	return func(nodeLabels client.MatchingLabels, consume nodeListConsumerFunc) error {
 		nodes := v1.NodeList{}
 		if err := c.KubeClient.List(ctx, &nodes, nodeLabels); err != nil {

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -33,8 +33,7 @@ import (
 )
 
 const (
-	controllerName = "NodeMetrics"
-
+	controllerName  = "NodeMetrics"
 	requeueInterval = 10 * time.Second
 )
 

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"time"
 
-	karpenterv1 "github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -82,7 +82,7 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 	return controllerruntime.
 		NewControllerManagedBy(m).
 		Named(controllerName).
-		For(&karpenterv1.Provisioner{}, builder.WithPredicates(
+		For(&v1alpha4.Provisioner{}, builder.WithPredicates(
 			predicate.Funcs{
 				CreateFunc:  func(_ event.CreateEvent) bool { return true },
 				DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
@@ -99,7 +99,7 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 // provisionerExists simply attempts to retrieve the provisioner from the Controller's Client
 // and returns any resulting error.
 func (c *Controller) provisionerExists(ctx context.Context, req reconcile.Request) error {
-	provisioner := karpenterv1.Provisioner{}
+	provisioner := v1alpha4.Provisioner{}
 	return c.KubeClient.Get(ctx, req.NamespacedName, &provisioner)
 }
 
@@ -108,7 +108,7 @@ func (c *Controller) provisionerExists(ctx context.Context, req reconcile.Reques
 // retrieving nodes then the error is returned without calling `consume`.
 func (c *Controller) consumeNodesFromKubeClientWithContext(ctx context.Context) consumeNodesWithFunc {
 	return func(nodeLabels client.MatchingLabels, consume nodeListConsumerFunc) error {
-		nodes := corev1.NodeList{}
+		nodes := v1.NodeList{}
 		if err := c.KubeClient.List(ctx, &nodes, nodeLabels); err != nil {
 			return err
 		}
@@ -118,5 +118,5 @@ func (c *Controller) consumeNodesFromKubeClientWithContext(ctx context.Context) 
 
 // consumeNoNodes calls `consume` with an empty slice and returns any resulting error.
 func consumeNoNodes(_ client.MatchingLabels, consume nodeListConsumerFunc) error {
-	return consume([]corev1.Node{})
+	return consume([]v1.Node{})
 }

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -1,0 +1,243 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"strings"
+
+	karpenterv1 "github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha4"
+	"github.com/awslabs/karpenter/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/multierr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricNamespace = metrics.KarpenterNamespace
+	metricSubsystem = "capacity"
+
+	metricLabelArch         = "arch"
+	metricLabelInstanceType = "instancetype"
+	metricLabelOs           = "os"
+	metricLabelProvisioner  = metrics.ProvisionerLabel
+	metricLabelZone         = "zone"
+
+	nodeLabelArch         = corev1.LabelArchStable
+	nodeLabelInstanceType = corev1.LabelInstanceTypeStable
+	nodeLabelOs           = corev1.LabelOSStable
+	nodeLabelZone         = corev1.LabelTopologyZone
+
+	nodeConditionTypeReady = corev1.NodeReady
+)
+
+type (
+	nodeListConsumerFunc = func([]corev1.Node) error
+	consumeNodesWithFunc = func(client.MatchingLabels, nodeListConsumerFunc) error
+)
+
+var (
+	nodeLabelProvisioner = karpenterv1.ProvisionerNameLabelKey
+
+	knownValuesForNodeLabels = karpenterv1.WellKnownLabels
+
+	nodeCountByProvisioner = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "node_count",
+			Help:      "Total node count by provisioner.",
+		},
+		[]string{
+			metricLabelProvisioner,
+		},
+	)
+
+	readyNodeCountByProvisionerZone = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "ready_node_count",
+			Help:      "Count of nodes that are ready by provisioner and zone.",
+		},
+		[]string{
+			metricLabelProvisioner,
+			metricLabelZone,
+		},
+	)
+
+	readyNodeCountByArchProvisionerZone = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "ready_node_arch_count",
+			Help:      "Count of nodes that are ready by architecture, provisioner, and zone.",
+		},
+		[]string{
+			metricLabelArch,
+			metricLabelProvisioner,
+			metricLabelZone,
+		},
+	)
+
+	readyNodeCountByInstancetypeProvisionerZone = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "ready_node_instancetype_count",
+			Help:      "Count of nodes that are ready by instance type, provisioner, and zone.",
+		},
+		[]string{
+			metricLabelInstanceType,
+			metricLabelProvisioner,
+			metricLabelZone,
+		},
+	)
+
+	readyNodeCountByOsProvisionerZone = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "ready_node_os_count",
+			Help:      "Count of nodes that are ready by operating system, provisioner, and zone.",
+		},
+		[]string{
+			metricLabelOs,
+			metricLabelProvisioner,
+			metricLabelZone,
+		},
+	)
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(nodeCountByProvisioner)
+	crmetrics.Registry.MustRegister(readyNodeCountByProvisionerZone)
+	crmetrics.Registry.MustRegister(readyNodeCountByArchProvisionerZone)
+	crmetrics.Registry.MustRegister(readyNodeCountByInstancetypeProvisionerZone)
+	crmetrics.Registry.MustRegister(readyNodeCountByOsProvisionerZone)
+}
+
+func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consumeNodesWithFunc) error {
+	archValues := knownValuesForNodeLabels[nodeLabelArch]
+	instanceTypeValues := knownValuesForNodeLabels[nodeLabelInstanceType]
+	osValues := knownValuesForNodeLabels[nodeLabelOs]
+	zoneValues := knownValuesForNodeLabels[nodeLabelZone]
+
+	errors := make([]error, 0, len(archValues)*len(instanceTypeValues)*len(osValues)*len(zoneValues))
+
+	// 1. Publish the count of all nodes associated with `provisioner`.
+	nodeLabels := client.MatchingLabels{nodeLabelProvisioner: provisioner}
+	errors = append(errors, consumeNodesWith(nodeLabels, func(nodes []corev1.Node) error {
+		return publishCount(nodeCountByProvisioner, metricLabelsFromNodeLabels(nodeLabels), len(nodes))
+	}))
+
+	for _, zone := range zoneValues {
+		// 2. Publish the count of all nodes associated with `provisioner`, in `zone`, and reported as "ready".
+		nodeLabels = client.MatchingLabels{
+			nodeLabelProvisioner: provisioner,
+			nodeLabelZone:        zone,
+		}
+		errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []corev1.Node) error {
+			return publishCount(readyNodeCountByProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+		})))
+
+		for _, arch := range archValues {
+			// 3. Publish the count of all nodes with `arch`, associated with `provisioner`, in `zone`, and reported as "ready".
+			nodeLabels := client.MatchingLabels{
+				nodeLabelArch:        arch,
+				nodeLabelProvisioner: provisioner,
+				nodeLabelZone:        zone,
+			}
+			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []corev1.Node) error {
+				return publishCount(readyNodeCountByArchProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+			})))
+		}
+
+		for _, instanceType := range instanceTypeValues {
+			// 4. Publish the count of all nodes with `instanceType`, associated with `provisioner`, in `zone`, and reported as "ready"
+			nodeLabels := client.MatchingLabels{
+				nodeLabelInstanceType: instanceType,
+				nodeLabelProvisioner:  provisioner,
+				nodeLabelZone:         zone,
+			}
+			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []corev1.Node) error {
+				return publishCount(readyNodeCountByInstancetypeProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+			})))
+		}
+
+		for _, os := range osValues {
+			// 5. Publish the count of all nodes with `os`, associated with `provisioner`, in `zone`, and reported as "ready".
+			nodeLabels := client.MatchingLabels{
+				nodeLabelOs:          os,
+				nodeLabelProvisioner: provisioner,
+				nodeLabelZone:        zone,
+			}
+			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []corev1.Node) error {
+				return publishCount(readyNodeCountByOsProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+			})))
+		}
+	}
+
+	// Combine will filter out `nil` values; if no errors remain then it will return `nil`.
+	return multierr.Combine(errors...)
+}
+
+// filterReadyNodes returns a new function that will filter "ready" nodes to pass on
+// to `consume`, and returns the result.
+func filterReadyNodes(consume nodeListConsumerFunc) nodeListConsumerFunc {
+	return func(nodes []corev1.Node) error {
+		readyNodes := make([]corev1.Node, 0, len(nodes))
+		for _, node := range nodes {
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == nodeConditionTypeReady && strings.ToLower(string(condition.Status)) == "true" {
+					readyNodes = append(readyNodes, node)
+				}
+			}
+		}
+		return consume(readyNodes)
+	}
+}
+
+func metricLabelsFromNodeLabels(nodeLabels client.MatchingLabels) (metricLabels prometheus.Labels) {
+	metricLabels = prometheus.Labels{}
+	// Exclude node label values that not present or are empty strings.
+	if arch := nodeLabels[nodeLabelArch]; arch != "" {
+		metricLabels[metricLabelArch] = arch
+	}
+	if instanceType := nodeLabels[nodeLabelInstanceType]; instanceType != "" {
+		metricLabels[metricLabelInstanceType] = instanceType
+	}
+	if os := nodeLabels[nodeLabelOs]; os != "" {
+		metricLabels[metricLabelOs] = os
+	}
+	if provisioner := nodeLabels[nodeLabelProvisioner]; provisioner != "" {
+		metricLabels[metricLabelProvisioner] = provisioner
+	}
+	if zone := nodeLabels[nodeLabelZone]; zone != "" {
+		metricLabels[metricLabelZone] = zone
+	}
+	return
+}
+
+func publishCount(gaugeVec *prometheus.GaugeVec, labels prometheus.Labels, count int) (err error) {
+	var gauge prometheus.Gauge
+	gauge, err = gaugeVec.GetMetricWith(labels)
+	if err != nil {
+		return
+	}
+	gauge.Set(float64(count))
+	return
+}

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -211,8 +211,8 @@ func filterReadyNodes(consume nodeListConsumerFunc) nodeListConsumerFunc {
 	}
 }
 
-func metricLabelsFrom(nodeLabels client.MatchingLabels) (metricLabels prometheus.Labels) {
-	metricLabels = prometheus.Labels{}
+func metricLabelsFrom(nodeLabels client.MatchingLabels) prometheus.Labels {
+	metricLabels := prometheus.Labels{}
 	// Exclude node label values that not present or are empty strings.
 	if arch := nodeLabels[nodeLabelArch]; arch != "" {
 		metricLabels[metricLabelArch] = arch
@@ -229,7 +229,7 @@ func metricLabelsFrom(nodeLabels client.MatchingLabels) (metricLabels prometheus
 	if zone := nodeLabels[nodeLabelZone]; zone != "" {
 		metricLabels[metricLabelZone] = zone
 	}
-	return
+	return metricLabels
 }
 
 func publishCount(gaugeVec *prometheus.GaugeVec, labels prometheus.Labels, count int) error {

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -32,13 +32,13 @@ const (
 
 	metricLabelArch         = "arch"
 	metricLabelInstanceType = "instancetype"
-	metricLabelOs           = "os"
+	metricLabelOS           = "os"
 	metricLabelProvisioner  = metrics.ProvisionerLabel
 	metricLabelZone         = "zone"
 
 	nodeLabelArch         = v1.LabelArchStable
 	nodeLabelInstanceType = v1.LabelInstanceTypeStable
-	nodeLabelOs           = v1.LabelOSStable
+	nodeLabelOS           = v1.LabelOSStable
 	nodeLabelZone         = v1.LabelTopologyZone
 
 	nodeConditionTypeReady = v1.NodeReady
@@ -115,7 +115,7 @@ var (
 			Help:      "Count of nodes that are ready by operating system, provisioner, and zone.",
 		},
 		[]string{
-			metricLabelOs,
+			metricLabelOS,
 			metricLabelProvisioner,
 			metricLabelZone,
 		},
@@ -133,7 +133,7 @@ func init() {
 func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consumeNodesWithFunc) error {
 	archValues := knownValuesForNodeLabels[nodeLabelArch]
 	instanceTypeValues := knownValuesForNodeLabels[nodeLabelInstanceType]
-	osValues := knownValuesForNodeLabels[nodeLabelOs]
+	osValues := knownValuesForNodeLabels[nodeLabelOS]
 	zoneValues := knownValuesForNodeLabels[nodeLabelZone]
 
 	errors := make([]error, 0, len(archValues)*len(instanceTypeValues)*len(osValues)*len(zoneValues))
@@ -181,7 +181,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		for _, os := range osValues {
 			// 5. Publish the count of all nodes with `os`, associated with `provisioner`, in `zone`, and reported as "ready".
 			nodeLabels := client.MatchingLabels{
-				nodeLabelOs:          os,
+				nodeLabelOS:          os,
 				nodeLabelProvisioner: provisioner,
 				nodeLabelZone:        zone,
 			}
@@ -220,8 +220,8 @@ func metricLabelsFromNodeLabels(nodeLabels client.MatchingLabels) (metricLabels 
 	if instanceType := nodeLabels[nodeLabelInstanceType]; instanceType != "" {
 		metricLabels[metricLabelInstanceType] = instanceType
 	}
-	if os := nodeLabels[nodeLabelOs]; os != "" {
-		metricLabels[metricLabelOs] = os
+	if os := nodeLabels[nodeLabelOS]; os != "" {
+		metricLabels[metricLabelOS] = os
 	}
 	if provisioner := nodeLabels[nodeLabelProvisioner]; provisioner != "" {
 		metricLabels[metricLabelProvisioner] = provisioner

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -138,16 +138,11 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 
 	errors := make([]error, 0, len(archValues)*len(instanceTypeValues)*len(osValues)*len(zoneValues))
 
-	// 1. Publish the count of all nodes associated with `provisioner`.
 	nodeLabels := client.MatchingLabels{nodeLabelProvisioner: provisioner}
 	errors = append(errors, consumeNodesWith(nodeLabels, func(nodes []v1.Node) error {
 		return publishCount(nodeCountByProvisioner, metricLabelsFrom(nodeLabels), len(nodes))
 	}))
 
-	// 2. Publish the count of all nodes associated with `provisioner`, in `zone`, and reported as "ready".
-	// 3. Publish the count of all nodes with `arch`, associated with `provisioner`, in `zone`, and reported as "ready".
-	// 4. Publish the count of all nodes with `instanceType`, associated with `provisioner`, in `zone`, and reported as "ready"
-	// 5. Publish the count of all nodes with `os`, associated with `provisioner`, in `zone`, and reported as "ready".
 	for _, zone := range zoneValues {
 		nodeLabels = client.MatchingLabels{
 			nodeLabelProvisioner: provisioner,
@@ -191,7 +186,6 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		}
 	}
 
-	// Combine will filter out `nil` values; if no errors remain then it will return `nil`.
 	return multierr.Combine(errors...)
 }
 

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -141,7 +141,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 	// 1. Publish the count of all nodes associated with `provisioner`.
 	nodeLabels := client.MatchingLabels{nodeLabelProvisioner: provisioner}
 	errors = append(errors, consumeNodesWith(nodeLabels, func(nodes []v1.Node) error {
-		return publishCount(nodeCountByProvisioner, metricLabelsFromNodeLabels(nodeLabels), len(nodes))
+		return publishCount(nodeCountByProvisioner, metricLabelsFrom(nodeLabels), len(nodes))
 	}))
 
 	for _, zone := range zoneValues {
@@ -151,7 +151,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 			nodeLabelZone:        zone,
 		}
 		errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []v1.Node) error {
-			return publishCount(readyNodeCountByProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+			return publishCount(readyNodeCountByProvisionerZone, metricLabelsFrom(nodeLabels), len(readyNodes))
 		})))
 
 		for _, arch := range archValues {
@@ -162,7 +162,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 				nodeLabelZone:        zone,
 			}
 			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []v1.Node) error {
-				return publishCount(readyNodeCountByArchProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+				return publishCount(readyNodeCountByArchProvisionerZone, metricLabelsFrom(nodeLabels), len(readyNodes))
 			})))
 		}
 
@@ -174,7 +174,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 				nodeLabelZone:         zone,
 			}
 			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []v1.Node) error {
-				return publishCount(readyNodeCountByInstancetypeProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+				return publishCount(readyNodeCountByInstancetypeProvisionerZone, metricLabelsFrom(nodeLabels), len(readyNodes))
 			})))
 		}
 
@@ -186,7 +186,7 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 				nodeLabelZone:        zone,
 			}
 			errors = append(errors, consumeNodesWith(nodeLabels, filterReadyNodes(func(readyNodes []v1.Node) error {
-				return publishCount(readyNodeCountByOsProvisionerZone, metricLabelsFromNodeLabels(nodeLabels), len(readyNodes))
+				return publishCount(readyNodeCountByOsProvisionerZone, metricLabelsFrom(nodeLabels), len(readyNodes))
 			})))
 		}
 	}
@@ -211,7 +211,7 @@ func filterReadyNodes(consume nodeListConsumerFunc) nodeListConsumerFunc {
 	}
 }
 
-func metricLabelsFromNodeLabels(nodeLabels client.MatchingLabels) (metricLabels prometheus.Labels) {
+func metricLabelsFrom(nodeLabels client.MatchingLabels) (metricLabels prometheus.Labels) {
 	metricLabels = prometheus.Labels{}
 	// Exclude node label values that not present or are empty strings.
 	if arch := nodeLabels[nodeLabelArch]; arch != "" {

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -144,8 +144,11 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		return publishCount(nodeCountByProvisioner, metricLabelsFrom(nodeLabels), len(nodes))
 	}))
 
+	// 2. Publish the count of all nodes associated with `provisioner`, in `zone`, and reported as "ready".
+	// 3. Publish the count of all nodes with `arch`, associated with `provisioner`, in `zone`, and reported as "ready".
+	// 4. Publish the count of all nodes with `instanceType`, associated with `provisioner`, in `zone`, and reported as "ready"
+	// 5. Publish the count of all nodes with `os`, associated with `provisioner`, in `zone`, and reported as "ready".
 	for _, zone := range zoneValues {
-		// 2. Publish the count of all nodes associated with `provisioner`, in `zone`, and reported as "ready".
 		nodeLabels = client.MatchingLabels{
 			nodeLabelProvisioner: provisioner,
 			nodeLabelZone:        zone,
@@ -155,7 +158,6 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		})))
 
 		for _, arch := range archValues {
-			// 3. Publish the count of all nodes with `arch`, associated with `provisioner`, in `zone`, and reported as "ready".
 			nodeLabels := client.MatchingLabels{
 				nodeLabelArch:        arch,
 				nodeLabelProvisioner: provisioner,
@@ -167,7 +169,6 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		}
 
 		for _, instanceType := range instanceTypeValues {
-			// 4. Publish the count of all nodes with `instanceType`, associated with `provisioner`, in `zone`, and reported as "ready"
 			nodeLabels := client.MatchingLabels{
 				nodeLabelInstanceType: instanceType,
 				nodeLabelProvisioner:  provisioner,
@@ -179,7 +180,6 @@ func publishNodeCountsForProvisioner(provisioner string, consumeNodesWith consum
 		}
 
 		for _, os := range osValues {
-			// 5. Publish the count of all nodes with `os`, associated with `provisioner`, in `zone`, and reported as "ready".
 			nodeLabels := client.MatchingLabels{
 				nodeLabelOS:          os,
 				nodeLabelProvisioner: provisioner,

--- a/pkg/controllers/metrics/node/counter.go
+++ b/pkg/controllers/metrics/node/counter.go
@@ -232,12 +232,10 @@ func metricLabelsFromNodeLabels(nodeLabels client.MatchingLabels) (metricLabels 
 	return
 }
 
-func publishCount(gaugeVec *prometheus.GaugeVec, labels prometheus.Labels, count int) (err error) {
-	var gauge prometheus.Gauge
-	gauge, err = gaugeVec.GetMetricWith(labels)
-	if err != nil {
-		return
+func publishCount(gaugeVec *prometheus.GaugeVec, labels prometheus.Labels, count int) error {
+	gauge, err := gaugeVec.GetMetricWith(labels)
+	if err == nil {
+		gauge.Set(float64(count))
 	}
-	gauge.Set(float64(count))
-	return
+	return err
 }


### PR DESCRIPTION
**1. Issue, if available:**
#612 "Emit Metrics for Karpenter"

This PR does not fully resolve the issue. More changes will be needed.

**2. Description of changes:**
Add a controller that runs periodically, and in response to some provisioner events, and publishes different counts of nodes broken out by zone, instance-type, etc.

**3. Does this change impact docs?**

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: link to issue
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
