### PR TITLE
upgrade to controller-gen 0.7.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -347,5 +347,5 @@ its target, and indicates whether or not those conditions are met.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7541834</code>.
+on git commit <code>2351fc2</code>.
 </em></p>

--- a/API.md
+++ b/API.md
@@ -347,5 +347,5 @@ its target, and indicates whether or not those conditions are met.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2351fc2</code>.
+on git commit <code>4bde595</code>.
 </em></p>

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ delete: ## Delete the controller from your ~/.kube/config cluster
 codegen: ## Generate code. Must be run if changes are made to ./pkg/apis/...
 	controller-gen \
 		object:headerFile="hack/boilerplate.go.txt" \
-		crd:trivialVersions=false \
+		crd \
 		paths="./pkg/..." \
 		output:crd:artifacts:config=charts/karpenter/templates
 	hack/boilerplate.sh

--- a/charts/karpenter/templates/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/templates/karpenter.sh_provisioners.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: provisioners.karpenter.sh
 spec:
@@ -143,7 +143,6 @@ spec:
                         transitioned from one status to another. We use VolatileTime
                         in place of metav1.Time to exclude this from creating equality.Semantic
                         differences (all other things held constant).
-                      format: date-time
                       type: string
                     message:
                       description: A human readable message indicating details about
@@ -170,7 +169,6 @@ spec:
               lastScaleTime:
                 description: LastScaleTime is the last time the Provisioner scaled
                   the number of nodes
-                format: date-time
                 type: string
             type: object
         type: object

--- a/charts/karpenter/templates/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/templates/karpenter.sh_provisioners.yaml
@@ -169,6 +169,7 @@ spec:
               lastScaleTime:
                 description: LastScaleTime is the last time the Provisioner scaled
                   the number of nodes
+                format: date-time
                 type: string
             type: object
         type: object

--- a/pkg/apis/provisioning/v1alpha4/provisioner_status.go
+++ b/pkg/apis/provisioning/v1alpha4/provisioner_status.go
@@ -22,6 +22,7 @@ type ProvisionerStatus struct {
 	// LastScaleTime is the last time the Provisioner scaled the number
 	// of nodes
 	// +optional
+	// +kubebuilder:validation:Format="date-time"
 	LastScaleTime *apis.VolatileTime `json:"lastScaleTime,omitempty"`
 
 	// Conditions is the set of conditions required for this provisioner to scale


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

the latest controller-gen doesn't work with the `trivialVersions` flag

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
