### PR TITLE
Update Container Day 2021 Link on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Follow the setup recommendations of your cloud provider.
 - [Contributing](CONTRIBUTING.md)
 
 ## Talks
-- [Karpenter @ Container Day, May 2021](https://www.twitch.tv/videos/1010593737?t=141m50s)
+- [Karpenter @ Container Day, May 2021](https://www.youtube.com/watch?v=MZ-4HzOC_ac)
 - [Groupless Autoscaling with Karpenter @ Kubecon, May 2021](https://www.youtube.com/watch?v=43g8uPohTgc)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Follow the setup recommendations of your cloud provider.
 - [Contributing](CONTRIBUTING.md)
 
 ## Talks
-- [Karpenter @ Container Day, May 2021](https://www.youtube.com/watch?v=MZ-4HzOC_ac)
+- [Karpenter @ Container Day, May 2021](https://youtu.be/MZ-4HzOC_ac?t=7137)
 - [Groupless Autoscaling with Karpenter @ Kubecon, May 2021](https://www.youtube.com/watch?v=43g8uPohTgc)
 
 ## License


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/738

**2. Description of changes:**
 - Twitch Container Day link on README was broken. Link to recording on youtube instead. 


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
