### PR TITLE
[AWS] Fix spurious launch template generation

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -270,7 +270,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 		nodeLabelArgs.WriteString("--node-labels=")
 		first := true
 		// Must be in sorted order or else eequivalent options won't
-		// hash the same
+		// hash the same.
 		for _, k := range sortedKeys(nodeLabels) {
 			if !first {
 				nodeLabelArgs.WriteString(",")
@@ -284,7 +284,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 		nodeTaintsArgs.WriteString("--register-with-taints=")
 		first := true
 		// Must be in sorted order or else equivalent options won't
-		// hash the same
+		// hash the same.
 		sorted := sortedTaints(constraints.Taints)
 		for _, taint := range sorted {
 			if !first {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -269,8 +269,8 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 	if len(nodeLabels) > 0 {
 		nodeLabelArgs.WriteString("--node-labels=")
 		first := true
-		// Must be in sorted order or else eequivalent options won't
-		// hash the same.
+		// Must be in sorted order or else equivalent options won't
+		// hash the same
 		for _, k := range sortedKeys(nodeLabels) {
 			if !first {
 				nodeLabelArgs.WriteString(",")

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -29,7 +29,6 @@ import (
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	v1alpha1 "github.com/awslabs/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/awslabs/karpenter/pkg/utils/functional"
-	"github.com/awslabs/karpenter/pkg/utils/pretty"
 	"github.com/awslabs/karpenter/pkg/utils/restconfig"
 	"github.com/mitchellh/hashstructure/v2"
 	core "k8s.io/api/core/v1"
@@ -206,15 +205,12 @@ func (ts taints) Len() int {
 func (ts taints) Less(i, j int) bool {
 	ti, tj := ts[i], ts[j]
 	if ti.Key < tj.Key {
-		fmt.Printf("key: %s %s\n", ti.Key, tj.Key)
 		return true
 	}
 	if ti.Key == tj.Key && ti.Value < tj.Value {
-		fmt.Printf("value: %s %s\n", ti.Value, tj.Value)
 		return true
 	}
 	if ti.Value == tj.Value {
-		fmt.Printf("value: %s %s\n", ti.Value, tj.Value)
 		return ti.Effect < tj.Effect
 	}
 	return false

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -210,11 +210,29 @@ func (ts taints) Len() int {
 
 func (ts taints) Less(i, j int) bool {
 	ti, tj := ts[i], ts[j]
-	return ti.Key < tj.Key && ti.Value < tj.Value && ti.Effect < tj.Effect
+	if ti.Key < tj.Key {
+		fmt.Printf("key: %s %s\n", ti.Key, tj.Key)
+		return true
+	}
+	if ti.Key == tj.Key && ti.Value < tj.Value {
+		fmt.Printf("value: %s %s\n", ti.Value, tj.Value)
+		return true
+	}
+	if ti.Value == tj.Value {
+		fmt.Printf("value: %s %s\n", ti.Value, tj.Value)
+		return ti.Effect < tj.Effect
+	}
+	return false
 }
 
 func (ts taints) Swap(i, j int) {
 	ts[i], ts[j] = ts[j], ts[i]
+}
+
+func sortedTaints(ts []core.Taint) []core.Taint {
+	sorted := taints(append(ts[:0:0], ts...)) // copy to avoid touching original
+	sort.Sort(sorted)
+	return sorted
 }
 
 func sortedKeys(m map[string]string) []string {
@@ -276,9 +294,10 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 		first := true
 		// Must be in sorted order or else eequivalent options won't
 		// hash the same
-		sortedTaints := taints(constraints.Taints)
-		sort.Sort(sortedTaints)
-		for _, taint := range sortedTaints {
+		fmt.Printf("XXX before: %+v\n", constraints.Taints)
+		sorted := sortedTaints(constraints.Taints)
+		fmt.Printf("XXX after: %+v\n", sorted)
+		for _, taint := range sorted {
 			if !first {
 				nodeTaintsArgs.WriteString(",")
 			}

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -283,7 +283,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 	if len(constraints.Taints) > 0 {
 		nodeTaintsArgs.WriteString("--register-with-taints=")
 		first := true
-		// Must be in sorted order or else eequivalent options won't
+		// Must be in sorted order or else equivalent options won't
 		// hash the same
 		sorted := sortedTaints(constraints.Taints)
 		for _, taint := range sorted {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -278,24 +278,30 @@ var _ = Describe("Allocation", func() {
 		Context("LaunchTemplates", func() {
 			FIt("should use same launch template for equivalent constraints", func() {
 				t1 := v1.Toleration{
-					Key:      "Foo",
+					Key:      "Abacus",
 					Operator: "Equal",
-					Value:    "Bar",
+					Value:    "Zebra",
 					Effect:   "NoSchedule",
 				}
 				t2 := v1.Toleration{
-					Key:      "Abra",
+					Key:      "Zebra",
 					Operator: "Equal",
-					Value:    "Cadabra",
+					Value:    "Abacus",
+					Effect:   "NoSchedule",
+				}
+				t3 := v1.Toleration{
+					Key:      "Boar",
+					Operator: "Equal",
+					Value:    "Abacus",
 					Effect:   "NoSchedule",
 				}
 
 				ExpectCreated(env.Client, provisioner)
 				pod1 := test.UnschedulablePod(test.PodOptions{
-					Tolerations: []v1.Toleration{t1, t2},
+					Tolerations: []v1.Toleration{t1, t2, t3},
 				})
 				pod2 := test.UnschedulablePod(test.PodOptions{
-					Tolerations: []v1.Toleration{t2, t1},
+					Tolerations: []v1.Toleration{t2, t3, t1},
 				})
 				// Ensure it's on its own node
 				pods := ExpectProvisioningSucceeded(ctx, env.Client, controller, provisioner, pod1)

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -276,7 +276,7 @@ var _ = Describe("Allocation", func() {
 			})
 		})
 		Context("LaunchTemplates", func() {
-			FIt("should use same launch template for equivalent constraints", func() {
+			It("should use same launch template for equivalent constraints", func() {
 				t1 := v1.Toleration{
 					Key:      "Abacus",
 					Operator: "Equal",


### PR DESCRIPTION
**1. Issue, if available:**

n/a

**2. Description of changes:**

Launch templates were getting generated spuriously if labels/taints (which make their way into the user data for the instance) were in a different order (even if equivalent). This fixes that by always sorting, and adds a unit test to catch (verified test failed with old code).

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
