### PR TITLE
fix aws cp caching empty instance types set

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -155,7 +155,7 @@ func (r Requirements) WithPod(pod *v1.Pod) Requirements {
 // Consolidate combines In and NotIn requirements for each unique key, producing
 // an equivalent minimal representation of the requirements. This is useful as
 // requirements may be appended from a variety of sources and then consolidated.
-// Caution: If a key has contains a `NotIn` operator without a corresponding
+// Caution: If a key contains a `NotIn` operator without a corresponding
 // `In` operator, the requirement will permanently be [] after consolidation. To
 // avoid this, include the broadest `In` requirements before consolidating.
 func (r Requirements) Consolidate() (requirements Requirements) {

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -48,7 +48,7 @@ const (
 	// resources. This value represents the maximum eventual consistency between
 	// AWS actual state and the controller's ability to provision those
 	// resources. Cache hits enable faster provisioning and reduced API load on
-	// AWS APIs, which can have a serious import on performance and scalability.
+	// AWS APIs, which can have a serious impact on performance and scalability.
 	// DO NOT CHANGE THIS VALUE WITHOUT DUE CONSIDERATION
 	CacheTTL = 60 * time.Second
 	// CacheCleanupInterval triggers cache cleanup (lazy eviction) at this interval.

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -88,7 +88,7 @@ func (p *InstanceTypeProvider) Get(ctx context.Context, constraints *v1alpha1.Co
 	return result, nil
 }
 
-func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context) (result map[string]sets.String, err error) {
+func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context) (map[string]sets.String, error) {
 	if cached, ok := p.cache.Get(instanceTypeZonesCacheKey); ok {
 		return cached.(map[string]sets.String), nil
 	}
@@ -111,7 +111,7 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context) (result
 }
 
 // getInstanceTypes retrieves all instance types from the ec2 DescribeInstanceTypes API using some opinionated filters
-func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (result map[string]*InstanceType, err error) {
+func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (map[string]*InstanceType, error) {
 	if cached, ok := p.cache.Get(instanceTypesCacheKey); ok {
 		return cached.(map[string]*InstanceType), nil
 	}

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -17,6 +17,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -30,8 +31,9 @@ import (
 )
 
 const (
-	instanceTypesCacheKey     = "types"
-	instanceTypeZonesCacheKey = "zones"
+	instanceTypesCacheKey         = "types"
+	instanceTypeZonesCacheKey     = "zones"
+	instanceTypesAndZonesCacheTTL = 5 * time.Minute
 )
 
 type InstanceTypeProvider struct {
@@ -44,7 +46,7 @@ func NewInstanceTypeProvider(ec2api ec2iface.EC2API, subnetProvider *SubnetProvi
 	return &InstanceTypeProvider{
 		ec2api:         ec2api,
 		subnetProvider: subnetProvider,
-		cache:          cache.New(CacheTTL, CacheCleanupInterval),
+		cache:          cache.New(instanceTypesAndZonesCacheTTL, CacheCleanupInterval),
 	}
 }
 
@@ -53,12 +55,12 @@ func (p *InstanceTypeProvider) Get(ctx context.Context, constraints *v1alpha1.Co
 	// Get InstanceTypes from EC2
 	instanceTypes, err := p.getInstanceTypes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving all instance types, %w", err)
+		return nil, err
 	}
 	// Get Viable AZs from subnets
 	subnets, err := p.subnetProvider.Get(ctx, constraints)
 	if err != nil {
-		return nil, fmt.Errorf("getting subnets, %w", err)
+		return nil, err
 	}
 	subnetZones := sets.NewString()
 	for _, subnet := range subnets {
@@ -90,7 +92,6 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context) (result
 	if cached, ok := p.cache.Get(instanceTypeZonesCacheKey); ok {
 		return cached.(map[string]sets.String), nil
 	}
-	defer func() { p.cache.SetDefault(instanceTypeZonesCacheKey, result) }()
 	zones := map[string]sets.String{}
 	if err := p.ec2api.DescribeInstanceTypeOfferingsPagesWithContext(ctx, &ec2.DescribeInstanceTypeOfferingsInput{LocationType: aws.String("availability-zone")},
 		func(output *ec2.DescribeInstanceTypeOfferingsOutput, lastPage bool) bool {
@@ -105,6 +106,7 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context) (result
 		return nil, fmt.Errorf("describing instance type zone offerings, %w", err)
 	}
 	logging.FromContext(ctx).Debugf("Discovered EC2 instance types zonal offerings")
+	p.cache.SetDefault(instanceTypeZonesCacheKey, zones)
 	return zones, nil
 }
 
@@ -113,7 +115,6 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (result map
 	if cached, ok := p.cache.Get(instanceTypesCacheKey); ok {
 		return cached.(map[string]*InstanceType), nil
 	}
-	defer func() { p.cache.SetDefault(instanceTypesCacheKey, result) }()
 	instanceTypes := map[string]*InstanceType{}
 	if err := p.ec2api.DescribeInstanceTypesPagesWithContext(ctx, &ec2.DescribeInstanceTypesInput{
 		Filters: []*ec2.Filter{
@@ -133,6 +134,7 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (result map
 		return nil, fmt.Errorf("fetching instance types using ec2.DescribeInstanceTypes, %w", err)
 	}
 	logging.FromContext(ctx).Debugf("Discovered %d EC2 instance types", len(instanceTypes))
+	p.cache.SetDefault(instanceTypesCacheKey, instanceTypes)
 	return instanceTypes, nil
 }
 


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
1. The AWS CP InstanceTypes provider was using a defer func to cache results. If the DescribeInstanceTypes call err'd for any reason, the defer block still runs and caches an empty value. On subsequent reconciliations, the scheduler would not fill in well known labels causing this logging:

```
2021-11-08T22:39:28.831Z	INFO	controller.allocation.provisioner/default	Ignored pod test1-basic-0-774f48fcd-hkf85/koi-test3, kubernetes.io/arch is too constrained: 
kubernetes.io/os is too constrained: 
node.kubernetes.io/instance-type is too constrained: 
```

2. The test I was running received a RequestLimitExceeded on the DescribeInstanceTypes call and resulted in an empty set of instance types cached. 

```
2021-11-08T22:39:23.117Z	ERROR	controller.controller.Allocation	Reconciler error	{"commit": "82226ca", "reconciler group": "karpenter.sh", "reconciler kind": "Provisioner", "name": "default", "namespace": "", "error": "getting instance types, retrieving all instance types, fetching instance types using ec2.DescribeInstanceTypes, RequestLimitExceeded: Request limit exceeded.\n\tstatus code: 503
```

Since DescribeInstanceTypes should change very rarely, I set a custom cache TTL for the instance types and zones cache. The default it was using was set to 1 minute. I set the new value to 5 minutes. 

3. I cleaned up some comment typos

4. Cleaned up some redundant error messages since we were wrapping and propagating errors in the InstanceTypes provider. 

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
