### PR TITLE
modify docs for helm default provisioner crd

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -156,8 +156,10 @@ eksctl. Thus, we don't need the helm chart to do that.
 ```bash
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
-helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
+helm upgrade --install --skip-crds karpenter karpenter/karpenter --namespace karpenter \
   --create-namespace --set serviceAccount.create=false --version 0.4.1 \
+  --set controller.clusterName=${CLUSTER_NAME} \
+  --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner
 ```
 
@@ -195,9 +197,6 @@ spec:
       values: ["spot"]
   provider:
     instanceProfile: KarpenterNodeInstanceProfile-${CLUSTER_NAME}
-    cluster:
-      name: ${CLUSTER_NAME}
-      endpoint: $(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json)
   ttlSecondsAfterEmpty: 30
 EOF
 ```


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Update docs for Helm installing a default provisioner now. Just skip-crd install in getting started guide for now since we'll probably need to think through how to present that.
 - Add `clusterName` and `clusterEndpoint` args to helm chart doc 


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
