### PR TITLE
fix error handling that somehow got dropped

### DIFF
--- a/pkg/controllers/allocation/launcher.go
+++ b/pkg/controllers/allocation/launcher.go
@@ -97,7 +97,7 @@ func (l *Launcher) bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) (err
 	// Bind pods
 	errs := make([]error, len(pods))
 	workqueue.ParallelizeUntil(ctx, len(pods), len(pods), func(i int) {
-		l.CoreV1Client.Pods(pods[i].Namespace).Bind(ctx, &v1.Binding{TypeMeta: pods[i].TypeMeta, ObjectMeta: pods[i].ObjectMeta, Target: v1.ObjectReference{Name: node.Name}}, metav1.CreateOptions{})
+		errs[i] = l.CoreV1Client.Pods(pods[i].Namespace).Bind(ctx, &v1.Binding{TypeMeta: pods[i].TypeMeta, ObjectMeta: pods[i].ObjectMeta, Target: v1.ObjectReference{Name: node.Name}}, metav1.CreateOptions{})
 	})
 	logging.FromContext(ctx).Infof("Bound %d pod(s) to node %s", len(pods)-len(multierr.Errors(multierr.Combine(errs...))), node.Name)
 	return multierr.Combine(errs...)


### PR DESCRIPTION
I remember it used to be there but seems to have gotten lost in some
PR

**1. Issue, if available:**

N/A

**2. Description of changes:**

Just make sure to keep track of the errors from parallel Bind calls.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
