### PR TITLE
Error out if no subnets found

### DIFF
--- a/pkg/cloudprovider/aws/subnets.go
+++ b/pkg/cloudprovider/aws/subnets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/awslabs/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/awslabs/karpenter/pkg/utils/pretty"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
 	"knative.dev/pkg/logging"
@@ -90,6 +91,9 @@ func (s *SubnetProvider) getSubnets(ctx context.Context, filters []*ec2.Filter) 
 	output, err := s.ec2api.DescribeSubnetsWithContext(ctx, &ec2.DescribeSubnetsInput{Filters: filters})
 	if err != nil {
 		return nil, fmt.Errorf("describing subnets %+v, %w", filters, err)
+	}
+	if len(output.Subnets) == 0 {
+		return nil, fmt.Errorf("no subnets found via %+v", pretty.Concise(filters))
 	}
 	s.cache.Set(fmt.Sprint(hash), output.Subnets, CacheTTL)
 	logging.FromContext(ctx).Debugf("Discovered subnets: %s", s.prettySubnets(output.Subnets))


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Before, if zero subnets were found (via the tag), the controller would continue on, even though there is no way for it to launch any instances. Now it errors with a message like:

```
2021-11-16T16:55:19.034Z	ERROR	controller.controller.Allocation	Reconciler error	{"commit": "53cd6c4", "reconciler group": "karpenter.sh", "reconciler kind": "Provisioner", "name": "default", "namespace": "", "error": "getting instance types, no subnets found via [{\"Name\":\"tag-key\",\"Values\":[\"kubernetes.io/cluster/foo-karpenter-demo.us-west-2.eksctl.io\"]}]"}
```

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
