### PR TITLE
move default provisioner to helm post-install hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ apply: ## Deploy the controller into your ~/.kube/config cluster
 
 delete: ## Delete the controller from your ~/.kube/config cluster
 	helm template karpenter charts/karpenter --namespace karpenter \
+		$(HELM_OPTS) \
 		--set serviceAccount.create=false \
-		--set defaultProvisioner.create=false \
 		| kubectl delete -f -
 
 codegen: ## Generate code. Must be run if changes are made to ./pkg/apis/...

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -48,6 +48,10 @@ spec:
             httpGet:
               path: /healthz
               port: 8081
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.controller.clusterName }}

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               port: 8081
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 8081
           env:
             - name: CLUSTER_NAME

--- a/charts/karpenter/templates/default_provisioner.yaml
+++ b/charts/karpenter/templates/default_provisioner.yaml
@@ -3,6 +3,9 @@ apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
   name: default
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/resource-policy": keep
 spec:
   {{ if .Values.defaultProvisioner.ttlSecondsAfterEmpty }}
     ttlSecondsAfterEmpty: {{ .Values.defaultProvisioner.ttlSecondsAfterEmpty }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.controller.clusterName }}

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -50,7 +50,10 @@ func (m *GenericControllerManager) RegisterControllers(ctx context.Context, cont
 		}
 	}
 	if err := m.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		panic(fmt.Sprintf("Failed to add readiness probe, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to add health probe, %s", err.Error()))
+	}
+	if err := m.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		panic(fmt.Sprintf("Failed to add ready probe, %s", err.Error()))
 	}
 	return m
 }

--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -157,7 +157,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version 0.4.2 \
+  --create-namespace --set serviceAccount.create=false --version 0.4.3 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --set defaultProvisioner.create=false \

--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -156,10 +156,11 @@ eksctl. Thus, we don't need the helm chart to do that.
 ```bash
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
-helm upgrade --install --skip-crds karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version 0.4.1 \
+helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
+  --create-namespace --set serviceAccount.create=false --version 0.4.2 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
+  --set defaultProvisioner.create=false \
   --wait # for the defaulting webhook to install before creating a Provisioner
 ```
 


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - When adding the default provisioner to the helm chart (https://github.com/awslabs/karpenter/pull/786), there is a race condition if you rely on defaulting from the webhook deployment since the provisioner resource is applied at the same time the webhook pod is coming online.  
 - This change moves the default provisioner to a helm `post-install-hook` resource. Helm resources applied in a post-install-hook are applied after the regular release resources are applied and are technically not part of the release. If you specify the `--wait` flag when helm installing, the post-install-hook will wait until release resources are in a Ready state. So, I have added readiness probes to both the controller and webhook deployments so that helm is signaled properly to begin the post-install-hook.  


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
