### PR TITLE
always tag instances with managed tags and provisioner tags

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
@@ -38,7 +38,7 @@ func ManagedTagsFor(clusterName string) map[string]string {
 	}
 }
 
-func MergeTagsFor(tags ...map[string]string) []*ec2.Tag {
+func MergeTags(tags ...map[string]string) []*ec2.Tag {
 	ec2Tags := []*ec2.Tag{}
 	for key, value := range functional.UnionStringMaps(tags...) {
 		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(key), Value: aws.String(value)})

--- a/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
@@ -16,6 +16,10 @@ package v1alpha1
 
 import (
 	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/karpenter/pkg/utils/functional"
 )
 
 const (
@@ -32,4 +36,12 @@ func ManagedTagsFor(clusterName string) map[string]string {
 		fmt.Sprintf(ClusterTagKeyFormat, clusterName):   "owned",
 		fmt.Sprintf(KarpenterTagKeyFormat, clusterName): "owned",
 	}
+}
+
+func MergeTagsFor(tags ...map[string]string) []*ec2.Tag {
+	ec2Tags := []*ec2.Tag{}
+	for key, value := range functional.UnionStringMaps(tags...) {
+		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+	return ec2Tags
 }

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -121,7 +121,6 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 	if err != nil {
 		return nil, fmt.Errorf("getting launch template configs, %w", err)
 	}
-	managedTags := v1alpha1.ManagedTagsFor(options.Get(ctx).ClusterName)
 	// Create fleet
 	createFleetOutput, err := p.ec2api.CreateFleetWithContext(ctx, &ec2.CreateFleetInput{
 		Type:                  aws.String(ec2.FleetTypeInstant),
@@ -133,7 +132,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String(ec2.ResourceTypeInstance),
-				Tags:         v1alpha1.MergeTagsFor(managedTags, constraints.Tags),
+				Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(options.Get(ctx).ClusterName), constraints.Tags),
 			},
 		},
 		// OnDemandOptions are allowed to be specified even when requesting spot

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -33,6 +33,7 @@ import (
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/awslabs/karpenter/pkg/cloudprovider"
 	"github.com/awslabs/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/awslabs/karpenter/pkg/utils/options"
 )
 
 type InstanceProvider struct {
@@ -120,6 +121,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 	if err != nil {
 		return nil, fmt.Errorf("getting launch template configs, %w", err)
 	}
+	managedTags := v1alpha1.ManagedTagsFor(options.Get(ctx).ClusterName)
 	// Create fleet
 	createFleetOutput, err := p.ec2api.CreateFleetWithContext(ctx, &ec2.CreateFleetInput{
 		Type:                  aws.String(ec2.FleetTypeInstant),
@@ -127,6 +129,12 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TargetCapacitySpecification: &ec2.TargetCapacitySpecificationRequest{
 			DefaultTargetCapacityType: aws.String(capacityType),
 			TotalTargetCapacity:       aws.Int64(int64(quantity)),
+		},
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String(ec2.ResourceTypeInstance),
+				Tags:         v1alpha1.MergeTagsFor(managedTags, constraints.Tags),
+			},
 		},
 		// OnDemandOptions are allowed to be specified even when requesting spot
 		OnDemandOptions: &ec2.OnDemandOptionsRequest{AllocationStrategy: aws.String(ec2.FleetOnDemandAllocationStrategyLowestPrice)},

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -169,7 +169,6 @@ func needsDocker(is []cloudprovider.InstanceType) bool {
 }
 
 func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, options *launchTemplateOptions) (*ec2.LaunchTemplate, error) {
-	managedTags := v1alpha1.ManagedTagsFor(options.ClusterName)
 	output, err := p.ec2api.CreateLaunchTemplateWithContext(ctx, &ec2.CreateLaunchTemplateInput{
 		LaunchTemplateName: aws.String(launchTemplateName(options)),
 		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
@@ -182,7 +181,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
-			Tags:         v1alpha1.MergeTagsFor(managedTags, options.Tags),
+			Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(options.ClusterName), options.Tags),
 		}},
 	})
 	if err != nil {


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/793

**2. Description of changes:**
 - Tag all fleet launches w/ managed tags and provisioner tags. Previously this only worked when using the LT that karpenter generates. This now works with custom LTs.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
