### PR TITLE
Protect the aws cloud provider from panicing if the provider-non-nil invariant is violated

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/awslabs/karpenter/pkg/apis/provisioning/v1alpha5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,9 @@ type AWS struct {
 }
 
 func Deserialize(constraints *v1alpha5.Constraints) (*Constraints, error) {
+	if constraints.Provider == nil {
+		return nil, fmt.Errorf("invariant violated: spec.provider is not defined. Is the defaulting webhook installed?")
+	}
 	aws := &AWS{}
 	_, gvk, err := Codec.UniversalDeserializer().Decode(constraints.Provider.Raw, nil, aws)
 	if err != nil {
@@ -63,6 +67,9 @@ func Deserialize(constraints *v1alpha5.Constraints) (*Constraints, error) {
 }
 
 func (a *AWS) Serialize(constraints *v1alpha5.Constraints) error {
+	if constraints.Provider == nil {
+		return fmt.Errorf("invariant violated: spec.provider is not defined. Is the defaulting webhook installed?")
+	}
 	bytes, err := json.Marshal(a)
 	if err != nil {
 		return err

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -307,6 +307,11 @@ var _ = Describe("Allocation", func() {
 		})
 	})
 	Context("Validation", func() {
+		It("should not panic if provider undefined", func() {
+			provisioner.Spec.Provider = nil
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
+
 		Context("SubnetSelector", func() {
 			It("should not allow empty string keys or values", func() {
 				for key, value := range map[string]string{


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/818

**2. Description of changes:**
Tested by deleting my webhooks and then removing the provider from my provisioner spec. The error was identical to what the customer reported.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
