### PR TITLE
add GitHub stars button

### DIFF
--- a/website/content/en/_index.html
+++ b/website/content/en/_index.html
@@ -11,11 +11,33 @@ linkTitle = "Home"
     <a class="btn btn-lg btn-dark col-sm-3 mb-3 font-weight-bold get-started" href="{{< relref "docs/getting-started" >}}">
       Get Started
     </a>
+    <div id="github-counter" class="btn btn-lg btn-dark col-sm-3 mb-3 font-weight-bold get-started" href="{{< relref "docs/getting-started" >}}">
+      <i class="fab fa-github"></i>
+      GitHub
+    </div>
+    <!-- Place this tag where you want the button to render. -->
+    <!-- Place this tag where you want the button to render. -->
+    
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script>
+      url = "https://api.github.com/repos/awslabs/karpenter"
+      fetch(url).then(function(response) {
+        return response.json();
+      }).then(function(data) {
+        stars = data.stargazers_count;
+        var element = document.getElementById("github-counter");
+        console.log(stars);
+        element.innerHTML = `<i class="fab fa-github"></i> Stars on Github: ${stars}`;
+      })
+    </script>
+    
   </div>
 </div>
 {{< /blocks/cover >}}
 
 {{< blocks/lead color="grey-100" height="med">}}
+
+<script async defer src="https://buttons.github.io/buttons.js"></script>
   <h2 class="mx-auto mt-5 col-sm-9 font-weight-bolder">
     Karpenter simplifies Kubernetes infrastructure with the right nodes at the right time.
   </h2>

--- a/website/content/en/_index.html
+++ b/website/content/en/_index.html
@@ -11,14 +11,10 @@ linkTitle = "Home"
     <a class="btn btn-lg btn-dark col-sm-3 mb-3 font-weight-bold get-started" href="{{< relref "docs/getting-started" >}}">
       Get Started
     </a>
-    <div id="github-counter" class="btn btn-lg btn-dark col-sm-3 mb-3 font-weight-bold get-started" href="{{< relref "docs/getting-started" >}}">
+    <a id="github-counter" class="btn btn-lg btn-dark col-sm-3 mb-3 font-weight-bold get-started" href="https://github.com/awslabs/karpenter">
       <i class="fab fa-github"></i>
       GitHub
-    </div>
-    <!-- Place this tag where you want the button to render. -->
-    <!-- Place this tag where you want the button to render. -->
-    
-    <!-- Place this tag in your head or just before your close body tag. -->
+    </a>
     <script>
       url = "https://api.github.com/repos/awslabs/karpenter"
       fetch(url).then(function(response) {

--- a/website/content/en/pre-docs/getting-started/_index.md
+++ b/website/content/en/pre-docs/getting-started/_index.md
@@ -294,7 +294,7 @@ kubectl delete node $NODE_NAME
 
 ## Cleanup
 
-To avoid additional charges, remove the demo infrastructure from your AWS account.
+To avoid additional charges, remove the demo infrastructure from your AWS account.  Party.
 
 ```bash
 helm uninstall karpenter --namespace karpenter
@@ -306,3 +306,9 @@ aws ec2 describe-launch-templates \
     | xargs -I{} aws ec2 delete-launch-template --launch-template-name {}
 eksctl delete cluster --name ${CLUSTER_NAME}
 ```
+
+---
+
+If you liked this demo, star us on GitHub!
+
+{{< github >}}

--- a/website/content/en/pre-docs/getting-started/_index.md
+++ b/website/content/en/pre-docs/getting-started/_index.md
@@ -294,7 +294,7 @@ kubectl delete node $NODE_NAME
 
 ## Cleanup
 
-To avoid additional charges, remove the demo infrastructure from your AWS account.  Party.
+To avoid additional charges, remove the demo infrastructure from your AWS account.
 
 ```bash
 helm uninstall karpenter --namespace karpenter

--- a/website/layouts/shortcodes/github.html
+++ b/website/layouts/shortcodes/github.html
@@ -1,0 +1,15 @@
+<a id="github-counter" class="btn btn-lg btn-dark font-weight-bold" href="https://github.com/awslabs/karpenter">
+    <i class="fab fa-github"></i>
+    GitHub
+  </a>
+  <script>
+    url = "https://api.github.com/repos/awslabs/karpenter"
+    fetch(url).then(function(response) {
+      return response.json();
+    }).then(function(data) {
+      stars = data.stargazers_count;
+      var element = document.getElementById("github-counter");
+      console.log(stars);
+      element.innerHTML = `<i class="fab fa-github"></i> Stars on Github: ${stars}`;
+    })
+  </script>

--- a/website/layouts/shortcodes/github.html
+++ b/website/layouts/shortcodes/github.html
@@ -13,3 +13,4 @@
       element.innerHTML = `<i class="fab fa-github"></i> Stars on Github: ${stars}`;
     })
   </script>
+  


### PR DESCRIPTION
**1. Issue, if available:**
#828 

**2. Description of changes:**
Add GitHub stars button to homepage and getting started guide.

It fetches the current star count with a basic get request to api.github.com

**3. Does this change impact docs?**
- [ x ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
