### PR TITLE
Moved faq and provisioner to new reference section

### DIFF
--- a/website/content/en/pre-docs/cloud-providers/AWS/aws-spec-fields.md
+++ b/website/content/en/pre-docs/cloud-providers/AWS/aws-spec-fields.md
@@ -4,7 +4,7 @@ linkTitle: "Spec Fields"
 weight: 10
 ---
 
-The [Provisioner CRD]({{< ref "pre-docs/provisioner-crd.md" >}}) supports defining
+The [Provisioner CRD]({{< ref "../../reference/provisioner-crd.md" >}}) supports defining
 node properties like instance type and zone. For certain well-known labels (documented below), Karpenter will provision
 nodes accordingly. For example, in response to a label of
 `topology.kubernetes.io/zone=us-east-1c`, Karpenter will provision nodes in

--- a/website/content/en/pre-docs/reference/_index.md
+++ b/website/content/en/pre-docs/reference/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Reference"
+linkTitle: "Reference"
+weight: 70
+description: >
+  Reference documentation for Karpenter
+---
+
+Reference documents for Karpenter

--- a/website/content/en/pre-docs/reference/faqs.md
+++ b/website/content/en/pre-docs/reference/faqs.md
@@ -2,6 +2,8 @@
 title: "FAQs"
 linkTitle: "FAQs"
 weight: 30
+description: >
+  Frequently Asked Questions about Karpenter
 ---
 
 ## General

--- a/website/content/en/pre-docs/reference/provisioner-crd.md
+++ b/website/content/en/pre-docs/reference/provisioner-crd.md
@@ -1,8 +1,10 @@
 ---
-title: "Provisioner CRD"
-linkTitle: "Provisioner CRD"
+title: "API (Provisioner CRD)"
+linkTitle: "API (Provisioner CRD)"
 weight: 40
 date: 2017-01-05
+description: >
+  Provisioner CRD reference page
 ---
 
 ## Example Provisioner Resource


### PR DESCRIPTION
As per our new docs organization, I moved the FAQ and provisioner CRD files to a new Reference section. I believe @ellistarn suggested some of the FAQ info is out of date and we might want to enhance the provisioner section. So I'm making this a WIP to work on those sections.