### PR TITLE
move grafana to subpage

### DIFF
--- a/website/content/en/pre-docs/getting-started/_index.md
+++ b/website/content/en/pre-docs/getting-started/_index.md
@@ -166,40 +166,6 @@ helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
 kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
 ```
 
-### Create Grafana dashboards (optional)
-
-The Karpenter repo contains multiple [importable dashboards](https://github.com/awslabs/karpenter/tree/main/grafana-dashboards) for an existing Grafana instance. See the Grafana documentation for [instructions](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) to import a dashboard.
-
-#### Deploy a temporary Prometheus and Grafana stack (optional)
-
-The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter.
-
-```sh
-helm repo add grafana-charts https://grafana.github.io/helm-charts
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-
-kubectl create namespace monitoring
-
-curl -fsSL https://karpenter.sh/docs/getting-started/prometheus-values.yaml
-helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
-
-curl -fsSL https://karpenter.sh/docs/getting-started/grafana-values.yaml
-helm install --namespace monitoring grafana grafana-charts/grafana --values grafana-values.yaml
-```
-
-The Grafana instance may be accessed using port forwarding.
-
-```sh
-kubectl port-forward --namespace monitoring svc/grafana 3000:80
-```
-
-The new stack has only one user, `admin`, and the password is stored in a secret. The following command will retrieve the password.
-
-```sh
-kubectl get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode
-```
-
 ### Provisioner
 
 A single Karpenter provisioner is capable of handling many different pod
@@ -312,3 +278,7 @@ eksctl delete cluster --name ${CLUSTER_NAME}
 If you liked this demo, star us on GitHub!
 
 {{< github >}}
+
+---
+
+## Next Steps:

--- a/website/content/en/pre-docs/getting-started/grafana.md
+++ b/website/content/en/pre-docs/getting-started/grafana.md
@@ -1,0 +1,38 @@
+
+---
+title: "Monitor Karpenter with Grafana Dashboards"
+linkTitle: "Grafana Dashboards"
+weight: 10
+---
+
+The Karpenter repo contains multiple [importable dashboards](https://github.com/awslabs/karpenter/tree/main/grafana-dashboards) for an existing Grafana instance. See the Grafana documentation for [instructions](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) to import a dashboard.
+
+#### Deploy a temporary Prometheus and Grafana stack (optional)
+
+The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter.
+
+```sh
+helm repo add grafana-charts https://grafana.github.io/helm-charts
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+kubectl create namespace monitoring
+
+curl -fsSL https://karpenter.sh/docs/getting-started/prometheus-values.yaml
+helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
+
+curl -fsSL https://karpenter.sh/docs/getting-started/grafana-values.yaml
+helm install --namespace monitoring grafana grafana-charts/grafana --values grafana-values.yaml
+```
+
+The Grafana instance may be accessed using port forwarding.
+
+```sh
+kubectl port-forward --namespace monitoring svc/grafana 3000:80
+```
+
+The new stack has only one user, `admin`, and the password is stored in a secret. The following command will retrieve the password.
+
+```sh
+kubectl get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode
+```


### PR DESCRIPTION
**1. Issue, if available:**
the getting started guide is a bit lengthy

**2. Description of changes:**
move the grafana dashboards section to a subpage

- reduces getting started guide length
- increases discoverability of grafana dashboards content 

**3. Does this change impact docs?**
- [ X ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
